### PR TITLE
Update editor sidebar and toolbar

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,10 +1,6 @@
 import React from "react";
-import toast from "react-hot-toast";
 import Link from "next/link";
 import styled from "styled-components";
-import { CanvasDirection } from "reaflow";
-import { TiFlowMerge } from "react-icons/ti";
-import { CgArrowsMergeAltH, CgArrowsShrinkH } from "react-icons/cg";
 import {
   AiOutlineDelete,
   AiFillGithub,
@@ -21,10 +17,11 @@ import { ImportModal } from "src/containers/Modals/ImportModal";
 import { ClearModal } from "src/containers/Modals/ClearModal";
 import { ShareModal } from "src/containers/Modals/ShareModal";
 import useConfig from "src/hooks/store/useConfig";
-import { getNextLayout } from "src/containers/Editor/LiveEditor/helpers";
 import { HiHeart } from "react-icons/hi";
 import shallow from "zustand/shallow";
 import { MdCenterFocusWeak } from "react-icons/md";
+import { TbSettings } from "react-icons/tb";
+import { Settings } from "src/containers/Editor/Settings";
 
 const StyledSidebar = styled.div`
   display: flex;
@@ -56,6 +53,7 @@ const StyledElement = styled.div<{ beta?: boolean }>`
   svg {
     padding: 8px;
     vertical-align: middle;
+    width: 24px;
   }
 
   a {
@@ -72,20 +70,12 @@ const StyledText = styled.span<{ secondary?: boolean }>`
     secondary ? theme.INTERACTIVE_NORMAL : theme.ORANGE};
 `;
 
-const StyledFlowIcon = styled(TiFlowMerge)<{ rotate: number }>`
-  transform: rotate(${({ rotate }) => `${rotate}deg`});
-`;
-
 const StyledTopWrapper = styled.nav`
   display: flex;
   justify-content: space-between;
   flex-direction: column;
   align-items: center;
   width: 100%;
-
-  & > div:nth-child(n + 1) {
-    border-bottom: 1px solid ${({ theme }) => theme.BACKGROUND_MODIFIER_ACCENT};
-  }
 
   .mobile {
     display: none;
@@ -115,11 +105,6 @@ const StyledBottomWrapper = styled.nav`
   align-items: center;
   width: 100%;
 
-  & > div,
-  a:nth-child(0) {
-    border-top: 1px solid ${({ theme }) => theme.BACKGROUND_MODIFIER_ACCENT};
-  }
-
   @media only screen and (max-width: 768px) {
     display: none;
   }
@@ -129,13 +114,6 @@ const StyledLogo = styled.div`
   color: ${({ theme }) => theme.FULL_WHITE};
 `;
 
-function rotateLayout(layout: CanvasDirection) {
-  if (layout === "LEFT") return 90;
-  if (layout === "UP") return 180;
-  if (layout === "RIGHT") return 270;
-  return 360;
-}
-
 export const Sidebar: React.FC = () => {
   const getJson = useConfig((state) => state.getJson);
   const setConfig = useConfig((state) => state.setConfig);
@@ -143,10 +121,11 @@ export const Sidebar: React.FC = () => {
   const [uploadVisible, setUploadVisible] = React.useState(false);
   const [clearVisible, setClearVisible] = React.useState(false);
   const [shareVisible, setShareVisible] = React.useState(false);
+  const [settingsVisible, setSettingsVisible] = React.useState(false);
   const { push } = useRouter();
 
-  const [expand, layout, hideEditor] = useConfig(
-    (state) => [state.expand, state.layout, state.hideEditor],
+  const [expand, hideEditor] = useConfig(
+    (state) => [state.expand, state.hideEditor],
     shallow
   );
 
@@ -157,16 +136,6 @@ export const Sidebar: React.FC = () => {
     a.href = window.URL.createObjectURL(file);
     a.download = "jsoncrack.json";
     a.click();
-  };
-
-  const toggleExpandCollapse = () => {
-    setConfig("expand", !expand);
-    toast(`${expand ? "Collapsed" : "Expanded"} nodes.`);
-  };
-
-  const toggleLayout = () => {
-    const nextLayout = getNextLayout(layout);
-    setConfig("layout", nextLayout);
   };
 
   return (
@@ -190,25 +159,9 @@ export const Sidebar: React.FC = () => {
             <AiOutlineFileAdd />
           </StyledElement>
         </Tooltip>
-        <Tooltip title="Rotate Layout">
-          <StyledElement onClick={toggleLayout}>
-            <StyledFlowIcon rotate={rotateLayout(layout)} />
-          </StyledElement>
-        </Tooltip>
         <Tooltip className="mobile" title="Center View">
           <StyledElement onClick={centerView}>
             <MdCenterFocusWeak />
-          </StyledElement>
-        </Tooltip>
-        <Tooltip
-          className="desktop"
-          title={expand ? "Shrink Nodes" : "Expand Nodes"}
-        >
-          <StyledElement
-            title="Toggle Expand/Collapse"
-            onClick={toggleExpandCollapse}
-          >
-            {expand ? <CgArrowsMergeAltH /> : <CgArrowsShrinkH />}
           </StyledElement>
         </Tooltip>
         <Tooltip className="desktop" title="Save JSON">
@@ -224,6 +177,14 @@ export const Sidebar: React.FC = () => {
         <Tooltip className="desktop" title="Share">
           <StyledElement onClick={() => setShareVisible(true)}>
             <AiOutlineLink />
+          </StyledElement>
+        </Tooltip>
+        <Tooltip className="desktop" title="Settings">
+          <StyledElement
+            aria-label="settings"
+            onClick={() => setSettingsVisible(true)}
+          >
+            <TbSettings />
           </StyledElement>
         </Tooltip>
       </StyledTopWrapper>
@@ -253,6 +214,7 @@ export const Sidebar: React.FC = () => {
       <ImportModal visible={uploadVisible} setVisible={setUploadVisible} />
       <ClearModal visible={clearVisible} setVisible={setClearVisible} />
       <ShareModal visible={shareVisible} setVisible={setShareVisible} />
+      <Settings visible={settingsVisible} setVisible={setSettingsVisible} />
     </StyledSidebar>
   );
 };

--- a/src/containers/Editor/Settings.tsx
+++ b/src/containers/Editor/Settings.tsx
@@ -27,12 +27,15 @@ export const Settings: React.FC<{
   visible: boolean;
   setVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({ visible, setVisible }) => {
+  const setLightTheme = useStored((state) => state.setLightTheme);
   const performanceMode = useConfig((state) => state.performanceMode);
   const [toggleHideCollapse, hideCollapse] = useStored(
     (state) => [state.toggleHideCollapse, state.hideCollapse],
     shallow
   );
   const setConfig = useConfig((state) => state.setConfig);
+  const lightmode = useStored((state) => state.lightmode);
+  const toggleTheme = () => setLightTheme(!lightmode);
 
   const togglePerformance = () => {
     const toastMsg = performanceMode
@@ -57,6 +60,9 @@ export const Settings: React.FC<{
           </StyledToggle>
           <StyledToggle onChange={togglePerformance} checked={performanceMode}>
             Performance Mode (Experimental)
+          </StyledToggle>
+          <StyledToggle onChange={toggleTheme} checked={!lightmode}>
+            Dark Mode
           </StyledToggle>
         </StyledModalWrapper>
       </Modal.Content>

--- a/src/containers/Editor/Tools.tsx
+++ b/src/containers/Editor/Tools.tsx
@@ -6,15 +6,18 @@ import {
 } from "react-icons/ai";
 import { FiDownload } from "react-icons/fi";
 import { HiOutlineSun, HiOutlineMoon } from "react-icons/hi";
+import { TiFlowMerge } from "react-icons/ti";
 import { MdCenterFocusWeak } from "react-icons/md";
+import { CgArrowsMergeAltH, CgArrowsShrinkH } from "react-icons/cg";
+import toast from "react-hot-toast";
+import { CanvasDirection } from "reaflow";
 import { SearchInput } from "src/components/SearchInput";
 import styled from "styled-components";
+import { getNextLayout } from "src/containers/Editor/LiveEditor/helpers";
 import useConfig from "src/hooks/store/useConfig";
 import shallow from "zustand/shallow";
 import { DownloadModal } from "../Modals/DownloadModal";
 import useStored from "src/hooks/store/useStored";
-import { TbSettings } from "react-icons/tb";
-import { Settings } from "./Settings";
 
 export const StyledTools = styled.div`
   display: flex;
@@ -46,14 +49,35 @@ const StyledToolElement = styled.button`
   }
 `;
 
+const Divider = styled.span`
+  height: 100%;
+  width: 1px;
+  background: ${({ theme }) => theme.BACKGROUND_MODIFIER_ACCENT};
+`;
+
+const StyledFlowIcon = styled(TiFlowMerge)<{ rotate: number }>`
+  transform: rotate(${({ rotate }) => `${rotate}deg`});
+`;
+
+function rotateLayout(layout: CanvasDirection) {
+  if (layout === "LEFT") return 90;
+  if (layout === "UP") return 180;
+  if (layout === "RIGHT") return 270;
+  return 360;
+}
+
 export const Tools: React.FC = () => {
-  const [settingsVisible, setSettingsVisible] = React.useState(false);
   const [isDownloadVisible, setDownloadVisible] = React.useState(false);
   const lightmode = useStored((state) => state.lightmode);
   const setLightTheme = useStored((state) => state.setLightTheme);
 
-  const [performanceMode, hideEditor] = useConfig(
-    (state) => [state.performanceMode, state.hideEditor],
+  const [performanceMode, layout, expand, hideEditor] = useConfig(
+    (state) => [
+      state.performanceMode,
+      state.layout,
+      state.expand,
+      state.hideEditor,
+    ],
     shallow
   );
 
@@ -64,17 +88,20 @@ export const Tools: React.FC = () => {
   const centerView = useConfig((state) => state.centerView);
   const toggleEditor = () => setConfig("hideEditor", !hideEditor);
   const toggleTheme = () => setLightTheme(!lightmode);
+  const toggleLayout = () => {
+    const nextLayout = getNextLayout(layout);
+    setConfig("layout", nextLayout);
+  };
+
+  const toggleExpandCollapse = () => {
+    setConfig("expand", !expand);
+    toast(`${expand ? "Collapsed" : "Expanded"} nodes.`);
+  };
 
   return (
     <StyledTools>
       <StyledToolElement aria-label="fullscreen" onClick={toggleEditor}>
         <AiOutlineFullscreen />
-      </StyledToolElement>
-      <StyledToolElement
-        aria-label="settings"
-        onClick={() => setSettingsVisible(true)}
-      >
-        <TbSettings />
       </StyledToolElement>
       <StyledToolElement aria-label="switch theme" onClick={toggleTheme}>
         {lightmode ? <HiOutlineMoon /> : <HiOutlineSun />}
@@ -89,6 +116,17 @@ export const Tools: React.FC = () => {
           <FiDownload />
         </StyledToolElement>
       )}
+      <Divider />
+      <StyledToolElement
+        aria-label={expand ? "shrink nodes" : "expand nodes"}
+        onClick={toggleExpandCollapse}
+      >
+        {expand ? <CgArrowsMergeAltH /> : <CgArrowsShrinkH />}
+      </StyledToolElement>
+      <StyledToolElement aria-label="toggle layout" onClick={toggleLayout}>
+        <StyledFlowIcon rotate={rotateLayout(layout)} />
+      </StyledToolElement>
+      <Divider />
       <StyledToolElement aria-label="center canvas" onClick={centerView}>
         <MdCenterFocusWeak />
       </StyledToolElement>
@@ -102,7 +140,6 @@ export const Tools: React.FC = () => {
         visible={isDownloadVisible}
         setVisible={setDownloadVisible}
       />
-      <Settings visible={settingsVisible} setVisible={setSettingsVisible} />
     </StyledTools>
   );
 };

--- a/src/containers/Editor/Tools.tsx
+++ b/src/containers/Editor/Tools.tsx
@@ -59,6 +59,10 @@ const StyledFlowIcon = styled(TiFlowMerge)<{ rotate: number }>`
   transform: rotate(${({ rotate }) => `${rotate}deg`});
 `;
 
+const SearchInputWrapper = styled.div`
+  margin-right: auto;
+`;
+
 function rotateLayout(layout: CanvasDirection) {
   if (layout === "LEFT") return 90;
   if (layout === "UP") return 180;
@@ -68,8 +72,6 @@ function rotateLayout(layout: CanvasDirection) {
 
 export const Tools: React.FC = () => {
   const [isDownloadVisible, setDownloadVisible] = React.useState(false);
-  const lightmode = useStored((state) => state.lightmode);
-  const setLightTheme = useStored((state) => state.setLightTheme);
 
   const [performanceMode, layout, expand, hideEditor] = useConfig(
     (state) => [
@@ -87,7 +89,6 @@ export const Tools: React.FC = () => {
   const zoomOut = useConfig((state) => state.zoomOut);
   const centerView = useConfig((state) => state.centerView);
   const toggleEditor = () => setConfig("hideEditor", !hideEditor);
-  const toggleTheme = () => setLightTheme(!lightmode);
   const toggleLayout = () => {
     const nextLayout = getNextLayout(layout);
     setConfig("layout", nextLayout);
@@ -103,10 +104,6 @@ export const Tools: React.FC = () => {
       <StyledToolElement aria-label="fullscreen" onClick={toggleEditor}>
         <AiOutlineFullscreen />
       </StyledToolElement>
-      <StyledToolElement aria-label="switch theme" onClick={toggleTheme}>
-        {lightmode ? <HiOutlineMoon /> : <HiOutlineSun />}
-      </StyledToolElement>
-      {!performanceMode && <SearchInput />}
 
       {!performanceMode && (
         <StyledToolElement
@@ -140,6 +137,11 @@ export const Tools: React.FC = () => {
         visible={isDownloadVisible}
         setVisible={setDownloadVisible}
       />
+      {!performanceMode && (
+        <SearchInputWrapper>
+          <SearchInput />
+        </SearchInputWrapper>
+      )}
     </StyledTools>
   );
 };


### PR DESCRIPTION
- [x] The dividers of the icons in the `Sidebar` have been removed.
- [x] `Rotate` and `Expand` items have been moved to the `Toolbar`.
- [x] Settings item moved to the `Sidebar`.
- [x] Theme options have been moved into Settings.
- [x] The search section has been moved to the left of the `Toolbar`.

**Before:**
![before](https://user-images.githubusercontent.com/7966133/187732713-0fe531a7-d324-4033-867d-073d873b709a.png)

**After:**
![editor-visible](https://user-images.githubusercontent.com/7966133/187731989-e5e56fbf-aa3e-48aa-82bf-53b668c5e679.png)
![editor-hidden](https://user-images.githubusercontent.com/7966133/187731998-b8b7b586-5c77-424d-a7c7-08e77dcfc484.png)
![theme-preferences](https://user-images.githubusercontent.com/7966133/187731996-f0cd509b-7dcc-4adf-b1df-5a53cf2df7bb.png)