### PR TITLE
Bug/share link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Builder
 FROM node:14-buster as builder
+ARG jsoncrack_host
+ENV NEXT_PUBLIC_JSONCRACK_HOST $jsoncrack_host
 WORKDIR /src
 COPY . /src
 RUN yarn install --legacy-peer-deps

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   </p>
 
   <p align="center">
-      <img width="800" src="/public/jsoncrack-screenshot.webp" alt="preview 1" />
+      <img width="800" src="./public/jsoncrack-screenshot.webp" alt="preview 1" />
   </p>
 
 # JSON Crack (jsoncrack.com)
@@ -59,7 +59,7 @@ You can use the web version at [jsoncrack.com](https://jsoncrack.com) or also ru
 A Docker file is provided in the root of the repository.
 If you want to run JSON Crack locally:
 
-* Build Docker image with `docker build -t jsoncrack .`
+* Build Docker image with `docker build -t jsoncrack --build-arg jsoncrack_host=localhost:8888 .`
 * Run locally with `docker run -p 8888:8080 jsoncrack`
 * Go to [http://localhost:8888]
 ```

--- a/src/containers/Modals/ShareModal/index.tsx
+++ b/src/containers/Modals/ShareModal/index.tsx
@@ -43,12 +43,14 @@ const StyledContainer = styled.div`
   }
 `;
 
+const jsoncrackHost = process.env.NEXT_PUBLIC_JSONCRACK_HOST || packageJson.homepage;
+
 export const ShareModal: React.FC<ModalProps> = ({ visible, setVisible }) => {
   const json = useConfig((state) => state.json);
   const [encodedJson, setEncodedJson] = React.useState("");
 
-  const embedText = `<iframe src="${packageJson.homepage}/widget?json=${encodedJson}" width="512" height="384" style="border: 2px solid #b9bbbe; border-radius: 6px;"></iframe>`;
-  const shareURL = `${packageJson.homepage}/editor?json=${encodedJson}`;
+  const embedText = `<iframe src="${jsoncrackHost}/widget?json=${encodedJson}" width="512" height="384" style="border: 2px solid #b9bbbe; border-radius: 6px;"></iframe>`;
+  const shareURL = `${jsoncrackHost}/editor?json=${encodedJson}`;
 
   React.useEffect(() => {
     const jsonEncode = compress(JSON.parse(json));


### PR DESCRIPTION
**The Problem**
I noticed that while running jsoncrack.com on Dockefile, the share link is pointing to jsoncrack.com, instead of my instance that running on localhost:8888.

![image](https://user-images.githubusercontent.com/23092765/188139643-a4f8b75a-62fd-4d1c-b02c-fe4f881585da.png)

**The Fix**
To fix that I created environment variable that is given in build time. The environment variable contains the host it running on. If the environment variable is not found its points to jsoncrack.com (in the package.json's homepage).

![image](https://user-images.githubusercontent.com/23092765/188140486-1f8862aa-e836-47ef-bcab-263a6d4093a6.png)
