### PR TITLE
fix: highlight red-dashed border display

### DIFF
--- a/src/components/CustomNode/styles.tsx
+++ b/src/components/CustomNode/styles.tsx
@@ -31,6 +31,7 @@ export const StyledForeignObject = styled.foreignObject<{
   &.searched {
     border: 2px solid ${({ theme }) => theme.TEXT_POSITIVE};
     border-radius: 2px;
+    box-sizing: border-box;
   }
 
   .highlight {
@@ -69,7 +70,8 @@ export const StyledKey = styled.span<{
   font-size: ${({ parent }) => parent && "14px"};
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: ${({ parent }) => parent && "10px"};
+  padding: ${({ parent }) => parent && "7px"};
+  height: 18px;
 `;
 
 export const StyledRow = styled.span.attrs<{


### PR DESCRIPTION
#164 
1. `box-sizing: border-box;`
    remain the <foreignObject/> height 40px (border-2px * 2, content 36px)
2. set height fixed `18px`; `padding:7px;`
    ![image](https://user-images.githubusercontent.com/57286895/189662770-33320f8e-28e4-48ce-b258-aa129c7acb0e.png)
    36px  (2*2 + 7*2 + 18)