### PR TITLE
fix: Remove browser scrolls bars around Editor container

### DIFF
--- a/src/containers/Editor/JsonEditor/index.tsx
+++ b/src/containers/Editor/JsonEditor/index.tsx
@@ -14,7 +14,7 @@ export const JsonEditor: React.FC = () => {
   const [hasError, setHasError] = React.useState(false);
 
   return (
-    <StyledEditorWrapper>
+    <StyledEditorWrapper id="testing-this">
       <ErrorContainer hasError={hasError} />
       <MonacoEditor setHasError={setHasError} />
     </StyledEditorWrapper>


### PR DESCRIPTION
### Description 
- On load, the horizontal scroll bar is visible on the `StyledEditorWrapper`. The vertical scroll bar appears intermittently based on viewport resizing
- Removing the `overflow: auto` from `StyledEditorWrapper` cleans up the scrollbars 

**Before**:

![jsoncrack before](https://user-images.githubusercontent.com/3803431/189702258-ac065859-0366-4a03-a42e-41db0bf5e57d.png)


**After**:
![jsoncrack after](https://user-images.githubusercontent.com/3803431/189702385-b742f454-ecd7-4b12-83d7-98c9a1ce51a4.png)


