### PR TITLE
Fix: Ignore mouse click events on expand buttons when panning; disable context menu on reaflow canvas

### DIFF
--- a/src/components/CustomNode/TextNode.tsx
+++ b/src/components/CustomNode/TextNode.tsx
@@ -4,6 +4,7 @@ import { MdLink, MdLinkOff } from "react-icons/md";
 import { CustomNodeProps } from "src/components/CustomNode";
 import useConfig from "src/hooks/store/useConfig";
 import useGraph from "src/hooks/store/useGraph";
+import usePanningStore from "src/hooks/store/usePanning";
 import useStored from "src/hooks/store/useStored";
 import styled from "styled-components";
 import * as Styled from "./styles";
@@ -48,13 +49,26 @@ const TextNode: React.FC<CustomNodeProps> = ({
   const collapseNodes = useGraph(state => state.collapseNodes);
   const isExpanded = useGraph(state => state.collapsedParents.includes(id));
   const performanceMode = useConfig(state => state.performanceMode);
+  const panning = usePanningStore(state => state.panning);
+  const setPanning = usePanningStore(state => state.setPanning);
   // const { inViewport } = useInViewport(ref);
 
   const handleExpand = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
 
-    if (!isExpanded) collapseNodes(id);
-    else expandNodes(id);
+    // Panning = true if the expand button was clicked down and then a panning
+    // event occurred, which indicates that the user was panning on top of an
+    // expand button, so we should disable its functionality for this press.
+    if (!panning) {
+      if (!isExpanded) collapseNodes(id);
+      else expandNodes(id);
+    }
+  };
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // Reset state of panning to detect whether a panning event occurs after
+    // this mouseDown event specifically
+    setPanning(false);
   };
 
   return (
@@ -82,7 +96,7 @@ const TextNode: React.FC<CustomNodeProps> = ({
         )}
 
         {inViewport && data.isParent && hasCollapse && !hideCollapse && (
-          <StyledExpand onClick={handleExpand}>
+          <StyledExpand onClick={handleExpand} onMouseDown={handleMouseDown}>
             {isExpanded ? <MdLinkOff size={18} /> : <MdLink size={18} />}
           </StyledExpand>
         )}

--- a/src/components/Graph/index.tsx
+++ b/src/components/Graph/index.tsx
@@ -8,6 +8,7 @@ import { Canvas, Edge, ElkRoot } from "reaflow";
 import { CustomNode } from "src/components/CustomNode";
 import useConfig from "src/hooks/store/useConfig";
 import useGraph from "src/hooks/store/useGraph";
+import usePanningStore from "src/hooks/store/usePanning";
 import styled from "styled-components";
 import { Loading } from "../Loading";
 import { ErrorView } from "./ErrorView";
@@ -48,6 +49,7 @@ const GraphComponent = ({
   const [minScale, setMinScale] = React.useState(0.4);
   const setGraphValue = useGraph(state => state.setGraphValue);
   const setConfig = useConfig(state => state.setConfig);
+  const setPanning = usePanningStore(state => state.setPanning);
   const centerView = useConfig(state => state.centerView);
   const loading = useGraph(state => state.loading);
   const layout = useConfig(state => state.layout);
@@ -117,7 +119,10 @@ const GraphComponent = ({
         zoomAnimation={{ animationType: "linear" }}
         doubleClick={{ disabled: true }}
         onInit={onInit}
-        onPanning={ref => ref.instance.wrapperComponent?.classList.add("dragging")}
+        onPanning={ref => {
+          ref.instance.wrapperComponent?.classList.add("dragging");
+          setPanning(true);
+        }}
         onPanningStop={ref =>
           ref.instance.wrapperComponent?.classList.remove("dragging")
         }

--- a/src/components/Graph/index.tsx
+++ b/src/components/Graph/index.tsx
@@ -109,7 +109,7 @@ const GraphComponent = ({
   if (nodes.length > 8_000) return <ErrorView />;
 
   return (
-    <StyledEditorWrapper isWidget={isWidget}>
+    <StyledEditorWrapper isWidget={isWidget} onContextMenu={e => e.preventDefault()}>
       {loading && <Loading message="Painting graph..." />}
       <TransformWrapper
         maxScale={2}

--- a/src/hooks/store/usePanning.tsx
+++ b/src/hooks/store/usePanning.tsx
@@ -1,0 +1,17 @@
+import create from "zustand";
+
+interface PanningState {
+  panning: boolean;
+  setPanning: (updatedPanningState: boolean) => void;
+}
+
+const usePanningStore = create<PanningState>()((set, get) => ({
+  panning: false,
+  setPanning: updatedPanningState => {
+    set(state => ({
+      panning: updatedPanningState,
+    }));
+  },
+}));
+
+export default usePanningStore;


### PR DESCRIPTION
Fixes #158 

#158 requests fixes for two panning-related issues: Buttons activating when they are incidentally clicked while the user is intending to simply pan the graph view, and the context menu appearing on right mouse button release after using right click to pan. This PR fixes both of those issues.

Let me know if you think these solutions are viable or if you have any questions. I think the expand button bugfix is pretty solid, but I'm not sure if you want the effects that come with the context menu fix (i.e. not being able to open a context menu on the reaflow canvas at all), but I thought that this was a simple and reasonable solution that most users would agree with.

Also, if there's anything you want me to change about this PR, please let me know and I will gladly alter it to make it satisfactory!