### PR TITLE
fix bug orden of elements in array

### DIFF
--- a/src/utils/jsonParser.ts
+++ b/src/utils/jsonParser.ts
@@ -123,21 +123,25 @@ const relationships = (xs: { id: string; children: never[] }[]) => {
 export const parser = (jsonStr: string, isExpanded = true) => {
   try {
     let json = JSON.parse(jsonStr);
+    
+    if(Array.isArray(json)) {
+      json = {"list": json};
+    }
+    
     if (!Array.isArray(json)) json = [json];
     const nodes: NodeData[] = [];
     const edges: EdgeData[] = [];
-
+    
     const mappedElements = extract(json, isExpanded);
     const res = [...flatten(mappedElements), ...relationships(mappedElements)];
 
     res.forEach(data => {
       if (isNode(data)) {
-        nodes.push(data);
+        nodes.push(data); 
       } else {
         edges.push(data);
       }
     });
-
     return { nodes, edges };
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
hey g.m i would like to review my code fix for this bug it seems as @eLeontev says earlier the package reaflow has some bugs when it has a array with more then 2 elements, in my implementation i check if is an array an then wrape this inside a object, i would like to know any suggestion of how to improve or resolve this bug, thanks.