### PR TITLE
Fixed Safari graph arrow orientation issue

### DIFF
--- a/src/components/Graph/CustomArrow.tsx
+++ b/src/components/Graph/CustomArrow.tsx
@@ -1,0 +1,41 @@
+import { Arrow, MarkerArrowProps } from "reaflow";
+
+type CustomArrowProps = Partial<
+  MarkerArrowProps & {
+    layout: string;
+  }
+>;
+
+export default function CustomArrow(props: CustomArrowProps) {
+  const size = props.size ? props.size : 8;
+  var angle: string;
+  switch (props.layout) {
+    case "UP":
+      angle = "270";
+      break;
+    case "LEFT":
+      angle = "180";
+      break;
+    case "DOWN":
+      angle = "90";
+      break;
+    case "RIGHT":
+    default:
+      angle = "0";
+      break;
+  }
+
+  return (
+    <marker
+      id="end-arrow"
+      key="end-arrow"
+      viewBox={`0 -${size / 2} ${size} ${size}`}
+      refX={`${size}`}
+      markerWidth={`${size}`}
+      markerHeight={`${size}`}
+      orient={angle}
+    >
+      <Arrow size={size} style={props.style} className={props.className} />
+    </marker>
+  );
+}

--- a/src/components/Graph/index.tsx
+++ b/src/components/Graph/index.tsx
@@ -8,8 +8,10 @@ import { Canvas, Edge, ElkRoot } from "reaflow";
 import { CustomNode } from "src/components/CustomNode";
 import useConfig from "src/hooks/store/useConfig";
 import useGraph from "src/hooks/store/useGraph";
+import { isSafari } from "src/utils/isSafari";
 import styled from "styled-components";
 import { Loading } from "../Loading";
+import CustomArrow from "./CustomArrow";
 import { ErrorView } from "./ErrorView";
 
 interface LayoutProps {
@@ -146,6 +148,7 @@ const GraphComponent = ({
             dragEdge={null}
             dragNode={null}
             fit={true}
+            arrow={isSafari ? <CustomArrow layout={layout} /> : undefined}
             node={props => <CustomNode {...props} onClick={handleNodeClick} />}
             edge={props => (
               <Edge {...props} containerClassName={`edge-${props.id}`} />

--- a/src/utils/isSafari.ts
+++ b/src/utils/isSafari.ts
@@ -1,0 +1,3 @@
+export const isSafari =
+  /Safari/i.test(window.navigator.userAgent) &&
+  /Apple Computer/.test(navigator.vendor);


### PR DESCRIPTION
Solves #155 

Safari has an issue with marker-end + orient attribute. This fix implements a custom edge arrow that rotates according to the layout rotation.