### PR TITLE
Added 'url' query parameter for loading JSON files.

### DIFF
--- a/src/components/MonacoEditor/index.tsx
+++ b/src/components/MonacoEditor/index.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { useRouter } from "next/router";
 import Editor, { loader, Monaco } from "@monaco-editor/react";
 import { parse } from "jsonc-parser";
 import { Loading } from "src/components/Loading";
 import useConfig from "src/hooks/store/useConfig";
 import useGraph from "src/hooks/store/useGraph";
 import useStored from "src/hooks/store/useStored";
+import fetchFileFromUrl from "src/utils/fetchFileFromUrl";
 import { parser } from "src/utils/jsonParser";
 import styled from "styled-components";
 
@@ -46,6 +48,14 @@ export const MonacoEditor = ({
   const setGraphValue = useGraph(state => state.setGraphValue);
   const lightmode = useStored(state => (state.lightmode ? "light" : "vs-dark"));
   const [value, setValue] = React.useState<string | undefined>("");
+  const router = useRouter();
+  const url = router.query.url;
+
+  React.useEffect(() => {
+    if (typeof url === "string") {
+      fetchFileFromUrl(url).then(json => setJson(json));
+    }
+  }, [setJson, url]);
 
   React.useEffect(() => {
     const { nodes, edges } = parser(json, expand);

--- a/src/components/MonacoEditor/index.tsx
+++ b/src/components/MonacoEditor/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import Editor, { loader, Monaco } from "@monaco-editor/react";
 import { parse } from "jsonc-parser";
+import toast from "react-hot-toast";
 import { Loading } from "src/components/Loading";
 import useConfig from "src/hooks/store/useConfig";
 import useGraph from "src/hooks/store/useGraph";
@@ -53,9 +54,19 @@ export const MonacoEditor = ({
 
   React.useEffect(() => {
     if (typeof url === "string") {
-      fetchFileFromUrl(url).then(json => setJson(json));
+      setGraphValue("loading", true);
+      fetchFileFromUrl(url)
+        .then(json => {
+          setJson(json);
+        })
+        .catch(() => {
+          toast.error("Failed to fetch remote file");
+        })
+        .finally(() => {
+          setGraphValue("loading", false);
+        });
     }
-  }, [setJson, url]);
+  }, [setGraphValue, setHasError, setJson, url]);
 
   React.useEffect(() => {
     const { nodes, edges } = parser(json, expand);

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -5,6 +5,7 @@ import { decompress } from "compress-json";
 import { parse } from "jsonc-parser";
 import { baseURL } from "src/constants/data";
 import useGraph from "src/hooks/store/useGraph";
+import fetchFileFromUrl from "src/utils/fetchFileFromUrl";
 import { isValidJson } from "src/utils/isValidJson";
 import { parser } from "src/utils/jsonParser";
 import styled from "styled-components";
@@ -43,7 +44,14 @@ const WidgetPage = () => {
   const setGraphValue = useGraph(state => state.setGraphValue);
 
   React.useEffect(() => {
-    if (query.json) {
+    if (typeof query.url === "string") {
+      fetchFileFromUrl(query.url).then(json => {
+        const { nodes, edges } = parser(json);
+
+        setGraphValue("nodes", nodes);
+        setGraphValue("edges", edges);
+      });
+    } else if (query.json) {
       const jsonURI = decodeURIComponent(query.json as string);
       const isJsonValid = isValidJson(jsonURI);
 
@@ -57,13 +65,17 @@ const WidgetPage = () => {
     }
 
     if (!inIframe()) push("/");
-  }, [push, query.json, setGraphValue]);
+  }, [push, query, setGraphValue]);
 
   return (
     <>
       <Graph isWidget />
       <StyledAttribute
-        href={`${baseURL}/editor?json=${query.json}`}
+        href={
+          typeof query.url === "string"
+            ? `${baseURL}/editor?url=${query.url}`
+            : `${baseURL}/editor?json=${query.json}`
+        }
         target="_blank"
         rel="noreferrer"
       >

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { decompress } from "compress-json";
 import { parse } from "jsonc-parser";
+import toast from "react-hot-toast";
 import { baseURL } from "src/constants/data";
 import useGraph from "src/hooks/store/useGraph";
 import fetchFileFromUrl from "src/utils/fetchFileFromUrl";
@@ -45,12 +46,22 @@ const WidgetPage = () => {
 
   React.useEffect(() => {
     if (typeof query.url === "string") {
-      fetchFileFromUrl(query.url).then(json => {
-        const { nodes, edges } = parser(json);
+      setGraphValue("loading", true);
+      setGraphValue("loading", true);
+      fetchFileFromUrl(query.url)
+        .then(json => {
+          const { nodes, edges } = parser(json);
 
-        setGraphValue("nodes", nodes);
-        setGraphValue("edges", edges);
-      });
+          setGraphValue("nodes", nodes);
+          setGraphValue("edges", edges);
+          setGraphValue("loading", false);
+        })
+        .catch(() => {
+          toast.error("Failed to fetch remote file");
+        })
+        .finally(() => {
+          setGraphValue("loading", false);
+        });
     } else if (query.json) {
       const jsonURI = decodeURIComponent(query.json as string);
       const isJsonValid = isValidJson(jsonURI);

--- a/src/utils/fetchFileFromUrl.ts
+++ b/src/utils/fetchFileFromUrl.ts
@@ -1,0 +1,3 @@
+export default async function fetchFileFromUrl(url: string) {
+  return await fetch(url).then(r => r.text());
+}


### PR DESCRIPTION
Solves #149

This adds a way to load JSON files via the 'url' query parameter

Example:
`/editor?url=http://ip.jsontest.com/`