### PR TITLE
Run yarn install before copying the directory to use cache effectively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Builder
 FROM node:14-buster as builder
 WORKDIR /src
-COPY . /src
+COPY package.json /src
+COPY yarn.lock /src
 RUN yarn install --legacy-peer-deps
+COPY . /src
 RUN yarn run build
 
 # App


### PR DESCRIPTION
Change the order of yarn install and copy to use cache effectively.
First build: 
<img width="505" alt="截屏2023-01-01 20 42 56" src="https://user-images.githubusercontent.com/71168966/210171412-d5e8ced4-677b-46cc-b9a5-6888064ac11c.png">
Build with cacheing:
<img width="504" alt="截屏2023-01-01 20 43 21" src="https://user-images.githubusercontent.com/71168966/210171432-6289a76d-f2ec-44b7-a97d-d7e53151dac8.png">
