### PR TITLE
Fix scrollbar - better in larger screens

### DIFF
--- a/src/containers/Editor/BottomBar.tsx
+++ b/src/containers/Editor/BottomBar.tsx
@@ -22,8 +22,8 @@ const StyledBottomBar = styled.div`
   justify-content: space-between;
   border-top: 1px solid ${({ theme }) => theme.BACKGROUND_MODIFIER_ACCENT};
   background: ${({ theme }) => theme.BACKGROUND_TERTIARY};
-  max-height: 28px;
-  height: 28px;
+  max-height: 27px;
+  height: 27px;
   padding: 0 6px;
 
   @media only screen and (max-width: 768px) {
@@ -51,7 +51,7 @@ const StyledBottomBarItem = styled.button`
   gap: 4px;
   width: fit-content;
   margin: 0;
-  height: 28px;
+  height: 27px;
   padding: 4px;
   font-size: 12px;
   font-weight: 400;

--- a/src/containers/Editor/JsonEditor/index.tsx
+++ b/src/containers/Editor/JsonEditor/index.tsx
@@ -7,7 +7,7 @@ const StyledEditorWrapper = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: auto;
+  overflow: hidden;
   user-select: none;
 `;
 export const JsonEditor: React.FC = () => {

--- a/src/containers/Editor/Panes.tsx
+++ b/src/containers/Editor/Panes.tsx
@@ -28,7 +28,7 @@ const Panes: React.FC = () => {
   return (
     <StyledEditor proportionalLayout={false} vertical={isMobile}>
       <Allotment.Pane
-        preferredSize={isMobile ? "100%" : 400}
+        preferredSize={isMobile ? "100%" : 410}
         minSize={fullscreen ? 0 : 300}
         maxSize={isMobile ? Infinity : 800}
         visible={!fullscreen}


### PR DESCRIPTION
# Issue 1
![issue1](https://user-images.githubusercontent.com/78584173/215268863-68b973bc-72f3-4b39-b77a-eba0d459c1d6.png)

Because the `BottomBar.tsx` component's height is set as `28px`, there was a small margin that created a scrollbar.

# Issue 2
![issue2](https://user-images.githubusercontent.com/78584173/215268816-6252ba7f-638e-4bad-bcb8-17712544e896.png)

Because `overflow: auto` was set, there was extra space as well as extra scrollbar.

https://user-images.githubusercontent.com/78584173/215269027-45c2efc2-0905-4bd7-815f-eff5dfbdf209.mp4

# Issue 3

https://user-images.githubusercontent.com/78584173/215269097-4610a22d-e351-4165-bc30-e93a95340c11.mp4

Just a tiniest bit small (`400px` to `410px` ) for example.

# Comparison
![comparison1](https://user-images.githubusercontent.com/78584173/215269172-919347bb-4f19-4711-bd8f-b2d4a44b9b9d.png)
![comparison2](https://user-images.githubusercontent.com/78584173/215269173-3109d990-355c-42b3-a490-94006041d2e0.png)
