### PR TITLE
added json data of editor to trigger useeffect [ issues/308]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "build": "next build && next export",
     "start": "next start",
-    "lint": "tsc && next lint",
+    "lint": "tsc && next lint && prettier --check src",
     "lint:fix": "prettier --write \"./**/*.{ts,tsx,json}\"",
     "deploy": "gh-pages -d out -t true"
   },

--- a/src/hooks/useFocusNode.tsx
+++ b/src/hooks/useFocusNode.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import useGraph from "src/store/useGraph";
 import { searchQuery, cleanupHighlight, highlightMatchedNodes } from "src/utils/search";
+import useJson from "src/store/useJson";
 
 export const useFocusNode = () => {
+  const json = useJson(state => state.json);
   const zoomPanPinch = useGraph(state => state.zoomPanPinch);
   const [selectedNode, setSelectedNode] = React.useState(0);
   const [nodeCount, setNodeCount] = React.useState(0);
@@ -22,6 +24,7 @@ export const useFocusNode = () => {
   }, [content.value]);
 
   React.useEffect(() => {
+    const changeJson = setTimeout(() => {
     if (!zoomPanPinch) return;
     const ref = zoomPanPinch.instance.wrapperComponent;
 
@@ -62,7 +65,9 @@ export const useFocusNode = () => {
         setNodeCount(0);
       }
     };
-  }, [content.debounced, content, selectedNode, zoomPanPinch]);
+  },50);
+  return () => clearTimeout(changeJson);
+  }, [content.debounced, content, selectedNode, zoomPanPinch, json]);
 
   return [content, setContent, skip, nodeCount, selectedNode] as const;
 };

--- a/src/hooks/useFocusNode.tsx
+++ b/src/hooks/useFocusNode.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import useGraph from "src/store/useGraph";
-import { searchQuery, cleanupHighlight, highlightMatchedNodes } from "src/utils/search";
 import useJson from "src/store/useJson";
+import { searchQuery, cleanupHighlight, highlightMatchedNodes } from "src/utils/search";
 
 export const useFocusNode = () => {
   const json = useJson(state => state.json);
@@ -25,48 +25,48 @@ export const useFocusNode = () => {
 
   React.useEffect(() => {
     const changeJson = setTimeout(() => {
-    if (!zoomPanPinch) return;
-    const ref = zoomPanPinch.instance.wrapperComponent;
+      if (!zoomPanPinch) return;
+      const ref = zoomPanPinch.instance.wrapperComponent;
 
-    const matchedNodes: NodeListOf<Element> = searchQuery(
-      `span[data-key*='${content.debounced}' i]`
-    );
-    const matchedNode: Element | null = matchedNodes[selectedNode] || null;
+      const matchedNodes: NodeListOf<Element> = searchQuery(
+        `span[data-key*='${content.debounced}' i]`
+      );
+      const matchedNode: Element | null = matchedNodes[selectedNode] || null;
 
-    cleanupHighlight();
+      cleanupHighlight();
 
-    if (ref && matchedNode && matchedNode.parentElement) {
-      const newScale = 0.8;
-      const x = Number(matchedNode.getAttribute("data-x"));
-      const y = Number(matchedNode.getAttribute("data-y"));
+      if (ref && matchedNode && matchedNode.parentElement) {
+        const newScale = 0.8;
+        const x = Number(matchedNode.getAttribute("data-x"));
+        const y = Number(matchedNode.getAttribute("data-y"));
 
-      const newPositionX =
-        (ref.offsetLeft - x) * newScale +
-        ref.clientWidth / 5 -
-        matchedNode.getBoundingClientRect().width / 5;
+        const newPositionX =
+          (ref.offsetLeft - x) * newScale +
+          ref.clientWidth / 5 -
+          matchedNode.getBoundingClientRect().width / 5;
 
-      const newPositionY =
-        (ref.offsetLeft - y) * newScale +
-        ref.clientHeight / 8 -
-        matchedNode.getBoundingClientRect().height / 8;
+        const newPositionY =
+          (ref.offsetLeft - y) * newScale +
+          ref.clientHeight / 8 -
+          matchedNode.getBoundingClientRect().height / 8;
 
-      highlightMatchedNodes(matchedNodes, selectedNode);
-      setNodeCount(matchedNodes.length);
+        highlightMatchedNodes(matchedNodes, selectedNode);
+        setNodeCount(matchedNodes.length);
 
-      zoomPanPinch?.setTransform(newPositionX, newPositionY, newScale);
-    } else {
-      setSelectedNode(0);
-      setNodeCount(0);
-    }
-
-    return () => {
-      if (!content.value) {
+        zoomPanPinch?.setTransform(newPositionX, newPositionY, newScale);
+      } else {
         setSelectedNode(0);
         setNodeCount(0);
       }
-    };
-  },100);
-  return () => clearTimeout(changeJson);
+
+      return () => {
+        if (!content.value) {
+          setSelectedNode(0);
+          setNodeCount(0);
+        }
+      };
+    }, 100);
+    return () => clearTimeout(changeJson);
   }, [content.debounced, content, selectedNode, zoomPanPinch, json]);
 
   return [content, setContent, skip, nodeCount, selectedNode] as const;

--- a/src/hooks/useFocusNode.tsx
+++ b/src/hooks/useFocusNode.tsx
@@ -65,7 +65,7 @@ export const useFocusNode = () => {
         setNodeCount(0);
       }
     };
-  },50);
+  },100);
   return () => clearTimeout(changeJson);
   }, [content.debounced, content, selectedNode, zoomPanPinch, json]);
 

--- a/src/hooks/useFocusNode.tsx
+++ b/src/hooks/useFocusNode.tsx
@@ -20,7 +20,13 @@ export const useFocusNode = () => {
       setContent(val => ({ ...val, debounced: content.value }));
     }, 800);
 
-    return () => clearTimeout(debouncer);
+    return () => {
+      clearTimeout(debouncer);
+      if (!content.value) {
+        setSelectedNode(0);
+        setNodeCount(0);
+      }
+    };
   }, [content.value]);
 
   React.useEffect(() => {
@@ -58,16 +64,9 @@ export const useFocusNode = () => {
         setSelectedNode(0);
         setNodeCount(0);
       }
-
-      return () => {
-        if (!content.value) {
-          setSelectedNode(0);
-          setNodeCount(0);
-        }
-      };
     }, 100);
     return () => clearTimeout(changeJson);
-  }, [content.debounced, content, selectedNode, zoomPanPinch, json]);
+  }, [content.debounced, selectedNode, zoomPanPinch, json]);
 
   return [content, setContent, skip, nodeCount, selectedNode] as const;
 };


### PR DESCRIPTION
@AykutSarac 

This PR is solution for https://github.com/AykutSarac/jsoncrack.com/issues/308

The issue is in useFocusNode.tsx file where useeffect is called which calls file search.tsx which adds or removes highlight class. But there is no relation for the json data provided in the editor, that's why on changing json Data from editor doesn't affect the highlight class.
json data is added in useFocusNode.tsx file and added in dependency array for useeffect() trigger.

Here search of node is based on class span[data-key*='${content.debounced}' i]
which is not updated as soon as json data is changed from editor, so adding 50ms timeout in useeffect() solves the issue as in this time span gets the class and search.tsx is able to identify the node.

[Issues308.webm](https://user-images.githubusercontent.com/51906755/220168017-7339f724-f00f-4fcc-82f7-01e2edcebda1.webm)

