### PR TITLE
 [BUG]: Docker build failing because no package-lock.json or npm-shrinkwrap.json present #316 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:14-alpine as builder
 WORKDIR /src
 COPY . /src/
-RUN npm ci && npm run build
+RUN npm install && npm run build
 
 # App
 FROM nginxinc/nginx-unprivileged


### PR DESCRIPTION
This pull requests resolves: https://github.com/AykutSarac/jsoncrack.com/issues/316

# Solution

One solution to fix the issue stated in https://github.com/AykutSarac/jsoncrack.com/issues/316 is to change the Dockerfile instruction to do:

```Dockerfile
RUN npm install && npm run build
``` 

instead of

```Dockerfile
RUN npm ci && npm run build
```

This results in a successful build:

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/22365519/223954882-0e2080f7-f447-4004-bd8a-03f2fb531e5a.png">

And a working container:

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/22365519/223955062-daef263d-2bd4-4eb8-acd0-ec49067588dd.png">

<img width="2055" alt="image" src="https://user-images.githubusercontent.com/22365519/223955122-d158ebe2-7f5a-4ba5-8a91-29616d9601b4.png">

# Other possible solution

An other solution would be to add a package-lock.json or npm-shrinkwrap.json, which is not implemented in this PR.
