### PR TITLE
Add useHotKey hook + import modal handling

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -16,6 +16,7 @@ import useJson from "src/store/useJson";
 import useModal from "src/store/useModal";
 import { getNextDirection } from "src/utils/getNextDirection";
 import styled from "styled-components";
+import { useHotkey } from "src/hooks/useHotKey";
 
 const StyledSidebar = styled.div`
   display: flex;
@@ -156,6 +157,11 @@ export const Sidebar: React.FC = () => {
   const foldNodes = useGraph(state => state.foldNodes);
   const fullscreen = useGraph(state => state.fullscreen);
   const graphCollapsed = useGraph(state => state.graphCollapsed);
+
+  useHotkey({
+    key: 'i',
+    callback: () => setVisible("import")(true)
+  })
 
   const handleSave = () => {
     const a = document.createElement("a");

--- a/src/hooks/useHotKey.ts
+++ b/src/hooks/useHotKey.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+type Key = string | number;
+
+type Props = {
+    key: string | number;
+    callback: () => void;
+}
+
+const isKeyMatch = (eventKey: string, key: string | number) => eventKey.toUpperCase() === key.toString().toUpperCase()
+
+export function useHotkey({key, callback} : Props) {
+  const [hotkeyPressed, setHotkeyPressed] = useState(false);
+ 
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isKeyMatch(event.key,key) && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        callback();
+        setHotkeyPressed(true);
+      }
+    }
+
+    function handleKeyUp(event: KeyboardEvent) {
+      // event.metaKey (for Mac) and the event.ctrlKey (for both Mac and Windows).
+      if (isKeyMatch(event.key,key)  && (event.ctrlKey || event.metaKey)) {
+        setHotkeyPressed(false);
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [key, callback]);
+
+  return hotkeyPressed;
+}


### PR DESCRIPTION
This PR adds a useHotKey hook for handling inputs of the form (cmd + ctrl)(some key). It works for both Mac and Windows. It also adds a handling for opening the import modal.