### PR TITLE
Fixed Issue: Objects and arrays get wrong parent if they have text nodes as siblings

### DIFF
--- a/src/utils/core/traverse.ts
+++ b/src/utils/core/traverse.ts
@@ -108,12 +108,12 @@ export const traverse = (
           e.objectsFromArrayId === states.objectsFromArray[states.objectsFromArray.length - 1]
       );
       if (
-        (brothersProps.length > 0 &&
+        ((brothersProps.length > 0 &&
           states.bracketOpen[states.bracketOpen.length - 2] &&
           states.bracketOpen[states.bracketOpen.length - 2].type !== "object") ||
-        (brothersProps.length > 0 && states.bracketOpen.length === 1)
+        (brothersProps.length > 0 && states.bracketOpen.length === 1) && brothersProps[brothersProps.length - 1].parentId)
       ) {
-        addEdgeToGraph(graph, brothersProps[brothersProps.length - 1].id, parentId);
+        addEdgeToGraph(graph, brothersProps[brothersProps.length - 1].parentId!, parentId);
       } else if (myParentId) {
         addEdgeToGraph(graph, myParentId, parentId);
       } else {


### PR DESCRIPTION
Link to issue: https://github.com/AykutSarac/jsoncrack.com/issues/320

Fix: brothers Id was being passed to addEdgeToGraph() in traverse() which was adding incorrect edge, that is, it was adding edge from brother to the node. Fixed it by passing brother's parentId so that new edge is created between parent and node.

Input:
```
{
  "body": [
    {
      "text": "klsadfkjasf",
      "jo": "mo",
      "object": {
        "test": 2
      },
      "array": [
        {
          "text": "khjasd",
          "operation": "lksfj",
          "action": {
            "url": "test.com"
          }
        }
      ]
    }
  ]
}
```
Output before:

![before](https://user-images.githubusercontent.com/16476523/232666957-6e149db5-6403-4422-8ed8-f77f9ecec25f.PNG)

Output After:

![after](https://user-images.githubusercontent.com/16476523/232667004-c2bf3353-9400-4906-a417-757bc11b729d.PNG)
