### PR TITLE
Fixed array length doesn't update

### DIFF
--- a/src/components/Graph/CustomNode/TextNode.tsx
+++ b/src/components/Graph/CustomNode/TextNode.tsx
@@ -100,7 +100,11 @@ const Node: React.FC<CustomNodeProps> = ({ node, x, y, hasCollapse = false }) =>
 };
 
 function propsAreEqual(prev: CustomNodeProps, next: CustomNodeProps) {
-  return prev.node.text === next.node.text && prev.node.width === next.node.width;
+  return (
+    prev.node.text === next.node.text &&
+    prev.node.width === next.node.width &&
+    prev.node.data.childrenCount === next.node.data.childrenCount
+  );
 }
 
 export const TextNode = React.memo(Node, propsAreEqual);


### PR DESCRIPTION
Fixes #345

- The TextNode component is not being re-rendered when the 'childrenCount' is updating.
- Added the condition that when it changes, it should re-render the component 
- Changes are made in the propsAreEqual function.

https://github.com/AykutSarac/jsoncrack.com/assets/74180320/2010cf3e-50f9-4748-a440-824e321e0c6f

