### PR TITLE
fix: Zoom label not updating on selection/input

### DIFF
--- a/src/containers/Views/GraphView/index.tsx
+++ b/src/containers/Views/GraphView/index.tsx
@@ -97,9 +97,6 @@ const GraphCanvas = ({ isWidget }: GraphProps) => {
   const direction = useGraph(state => state.direction);
   const nodes = useGraph(state => state.nodes);
   const edges = useGraph(state => state.edges);
-  const viewPort = useGraph(state => state.viewPort);
-  const setViewPort = useGraph(state => state.setViewPort);
-
   const [paneWidth, setPaneWidth] = React.useState(2000);
   const [paneHeight, setPaneHeight] = React.useState(2000);
 

--- a/src/containers/Views/GraphView/index.tsx
+++ b/src/containers/Views/GraphView/index.tsx
@@ -96,14 +96,16 @@ const GraphCanvas = ({ isWidget }: GraphProps) => {
   const direction = useGraph(state => state.direction);
   const nodes = useGraph(state => state.nodes);
   const edges = useGraph(state => state.edges);
+  const viewPort = useGraph(state => state.viewPort);
+  const setViewPort = useGraph(state => state.setViewPort);
 
   const [paneWidth, setPaneWidth] = React.useState(2000);
   const [paneHeight, setPaneHeight] = React.useState(2000);
 
   const onLayoutChange = React.useCallback(
     (layout: ElkRoot) => {
-      if (layout.width && layout.height) {
-        const areaSize = layout.width * layout.height;
+            if (layout.width && layout.height) {
+                const areaSize = layout.width * layout.height;
         const changeRatio = Math.abs((areaSize * 100) / (paneWidth * paneHeight) - 100);
 
         setPaneWidth(layout.width + 50);
@@ -137,12 +139,15 @@ const GraphCanvas = ({ isWidget }: GraphProps) => {
       layoutOptions={layoutOptions}
       key={direction}
       pannable={false}
-      zoomable={false}
+      zoomable={true}
       animated={false}
       readonly={true}
       dragEdge={null}
       dragNode={null}
       fit={true}
+      onZoomChange={() => {
+        setViewPort(viewPort!);
+      }}
     />
   );
 };
@@ -210,7 +215,7 @@ export const Graph = ({ isWidget = false }: GraphProps) => {
           treatTwoFingerTrackPadGesturesLikeTouch={gesturesEnabled}
           pollForElementResizing
           className="jsoncrack-space"
-        >
+                  >
           <GraphCanvas isWidget={isWidget} />
         </Space>
       </StyledEditorWrapper>

--- a/src/store/useGraph.ts
+++ b/src/store/useGraph.ts
@@ -194,14 +194,17 @@ const useGraph = create<Graph & GraphActions>((set, get) => ({
   setZoomFactor: zoomFactor => {
     const viewPort = get().viewPort;
     viewPort?.camera?.recenter(viewPort.centerX, viewPort.centerY, zoomFactor);
+    set({ viewPort });
   },
   zoomIn: () => {
     const viewPort = get().viewPort;
     viewPort?.camera?.recenter(viewPort.centerX, viewPort.centerY, viewPort.zoomFactor + 0.1);
+    set({viewPort})
   },
   zoomOut: () => {
     const viewPort = get().viewPort;
     viewPort?.camera?.recenter(viewPort.centerX, viewPort.centerY, viewPort.zoomFactor - 0.1);
+    set({ viewPort });
   },
   centerView: () => {
     const viewPort = get().viewPort;
@@ -211,6 +214,7 @@ const useGraph = create<Graph & GraphActions>((set, get) => ({
     if (canvas) {
       viewPort?.camera?.centerFitElementIntoView(canvas);
     }
+    set({ viewPort });
   },
   toggleFullscreen: fullscreen => set({ fullscreen }),
   setViewPort: viewPort => set({ viewPort }),

--- a/src/store/useGraph.ts
+++ b/src/store/useGraph.ts
@@ -194,17 +194,14 @@ const useGraph = create<Graph & GraphActions>((set, get) => ({
   setZoomFactor: zoomFactor => {
     const viewPort = get().viewPort;
     viewPort?.camera?.recenter(viewPort.centerX, viewPort.centerY, zoomFactor);
-    set({ viewPort });
   },
   zoomIn: () => {
     const viewPort = get().viewPort;
     viewPort?.camera?.recenter(viewPort.centerX, viewPort.centerY, viewPort.zoomFactor + 0.1);
-    set({viewPort})
   },
   zoomOut: () => {
     const viewPort = get().viewPort;
     viewPort?.camera?.recenter(viewPort.centerX, viewPort.centerY, viewPort.zoomFactor - 0.1);
-    set({ viewPort });
   },
   centerView: () => {
     const viewPort = get().viewPort;
@@ -214,7 +211,6 @@ const useGraph = create<Graph & GraphActions>((set, get) => ({
     if (canvas) {
       viewPort?.camera?.centerFitElementIntoView(canvas);
     }
-    set({ viewPort });
   },
   toggleFullscreen: fullscreen => set({ fullscreen }),
   setViewPort: viewPort => set({ viewPort }),


### PR DESCRIPTION

**### Issue**:

This pull request addresses the issue where the zoom label next to the zoom dropdown and input field does not update to reflect the selected zoom level (Issue #388 ).

### Description:

This PR implements a fix that ensures the zoom label accurately displays the chosen zoom level, regardless of whether it's selected from the dropdown or entered in the input field.

### Changes:
Added a code block that dynamically updates the viewport in real-time as the user adjusts the zoom level. 
Because we are displaying the zoomFactor propery of viewport in the zoom label which was not updating

This enhancement ensures immediate synchronization between the user's zoom actions and the displayed viewport. Prior to this update, the viewport did not reflect changes in zoom levels promptly, resulting in the display of outdated information on the zoom label. 
