### PR TITLE
Add last saved timestamp to status bar

### DIFF
--- a/src/containers/Editor/BottomBar.tsx
+++ b/src/containers/Editor/BottomBar.tsx
@@ -126,22 +126,32 @@ export const BottomBar = () => {
       try {
         setIsUpdating(true);
         toast.loading("Saving document...", { id: "fileSave" });
+        console.log("Saving document...");
+        console.log(query.json);
+        console.log(getContents());
 
         const { data, error } = await documentSvc.upsert({
           id: query?.json,
           contents: getContents(),
           format: getFormat(),
+          lastSaved: new Date().toISOString(),
         });
 
         if (error) throw error;
+        console.log(data);
         if (data) {
-          await documentSvc.updateLastSaved(query.json as string, new Date().toISOString());
+          // await documentSvc.updateLastSaved(query.json as string, new Date().toISOString());
+          await documentSvc.update(query.json as string, {
+            lastSaved: new Date().toISOString(),
+          });
           setLastSaved(new Date().toISOString());
           replace({ query: { json: query.json } });
           toast.success("Document saved to cloud", { id: "fileSave" });
+          console.log("Document saved to cloud");
           setHasChanges(false);
         }
       } catch (error: any) {
+        console.error(error);
         toast.error(error.message, { id: "fileSave" });
       } finally {
         setIsUpdating(false);
@@ -171,7 +181,9 @@ export const BottomBar = () => {
       if (error) return toast.error(error.message);
 
       if (updatedJsonData[0]) {
-        await documentSvc.updateLastSaved(query.json as string, new Date().toISOString());
+        await documentSvc.update(query.json as string, {
+          lastSaved: new Date().toISOString(),
+        });
         setIsPrivate(updatedJsonData[0].private);
         toast.success(`Document set to ${isPrivate ? "public" : "private"}.`);
       } else throw error;
@@ -233,7 +245,7 @@ export const BottomBar = () => {
           </StyledBottomBarItem>
         )}
         {lastSaved && (
-          <StyledBottomBarItem>
+          <StyledBottomBarItem disabled>
             <AiOutlineClockCircle />
             Last saved: {lastSaved}
           </StyledBottomBarItem>

--- a/src/containers/Editor/BottomBar.tsx
+++ b/src/containers/Editor/BottomBar.tsx
@@ -126,9 +126,6 @@ export const BottomBar = () => {
       try {
         setIsUpdating(true);
         toast.loading("Saving document...", { id: "fileSave" });
-        console.log("Saving document...");
-        console.log(query.json);
-        console.log(getContents());
 
         const { data, error } = await documentSvc.upsert({
           id: query?.json,
@@ -138,20 +135,16 @@ export const BottomBar = () => {
         });
 
         if (error) throw error;
-        console.log(data);
         if (data) {
-          // await documentSvc.updateLastSaved(query.json as string, new Date().toISOString());
           await documentSvc.update(query.json as string, {
             lastSaved: new Date().toISOString(),
           });
           setLastSaved(new Date().toISOString());
           replace({ query: { json: query.json } });
           toast.success("Document saved to cloud", { id: "fileSave" });
-          console.log("Document saved to cloud");
           setHasChanges(false);
         }
       } catch (error: any) {
-        console.error(error);
         toast.error(error.message, { id: "fileSave" });
       } finally {
         setIsUpdating(false);

--- a/src/containers/Editor/BottomBar.tsx
+++ b/src/containers/Editor/BottomBar.tsx
@@ -194,6 +194,21 @@ export const BottomBar = () => {
     }
   };
 
+  function formatDate(isoString) {
+    const date = new Date(isoString);
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: true,
+    };
+    return `Last saved: ${date.toLocaleDateString("en-US", options)}`;
+  }
+
   return (
     <StyledBottomBar>
       {data?.name && (
@@ -247,7 +262,7 @@ export const BottomBar = () => {
         {lastSaved && (
           <StyledBottomBarItem disabled>
             <AiOutlineClockCircle />
-            Last saved: {lastSaved}
+            {formatDate(lastSaved)}
           </StyledBottomBarItem>
         )}
         {data?.owner_email === user?.email && (

--- a/src/containers/Editor/BottomBar.tsx
+++ b/src/containers/Editor/BottomBar.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import {
   AiOutlineCloudSync,
   AiOutlineCloudUpload,
+  AiOutlineClockCircle,
   AiOutlineLink,
   AiOutlineLock,
   AiOutlineUnlock,
@@ -233,7 +234,8 @@ export const BottomBar = () => {
         )}
         {lastSaved && (
           <StyledBottomBarItem>
-            <Text>Last saved: {lastSaved}</Text>
+            <AiOutlineClockCircle />
+            Last saved: {lastSaved}
           </StyledBottomBarItem>
         )}
         {data?.owner_email === user?.email && (

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -9,6 +9,7 @@ type CloudSave = {
   id?: string;
   contents: string;
   format: FileFormat;
+  lastSaved: string;
 };
 
 export const documentSvc = {
@@ -18,6 +19,7 @@ export const documentSvc = {
       p_content,
       p_format,
       p_id,
+      p_last_saved: new Date().toISOString(),
     });
   },
   getById: async (doc_id: string): Promise<PostgrestSingleResponse<File[]>> => {
@@ -45,8 +47,5 @@ export const documentSvc = {
   },
   delete: async (id: string) => {
     await supabase.from("document").delete().eq("id", id);
-  },
-  updateLastSaved: async (id: string, lastSaved: string) => {
-    return await supabase.from("document").update({ last_saved: lastSaved }).eq("id", id);
   },
 };

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -46,4 +46,7 @@ export const documentSvc = {
   delete: async (id: string) => {
     await supabase.from("document").delete().eq("id", id);
   },
+  updateLastSaved: async (id: string, lastSaved: string) => {
+    return await supabase.from("document").update({ last_saved: lastSaved }).eq("id", id);
+  },
 };

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -14,12 +14,17 @@ type CloudSave = {
 
 export const documentSvc = {
   upsert: async (args: CloudSave): Promise<PostgrestSingleResponse<string>> => {
-    const { id: p_id = "", contents: p_content, format: p_format = FileFormat.JSON } = args;
+    const {
+      id: p_id = "",
+      contents: p_content,
+      format: p_format = FileFormat.JSON,
+      lastSaved: p_last_saved,
+    } = args;
     return await supabase.rpc("upsert_document", {
       p_content,
       p_format,
       p_id,
-      p_last_saved: new Date().toISOString(),
+      p_last_saved,
     });
   },
   getById: async (doc_id: string): Promise<PostgrestSingleResponse<File[]>> => {


### PR DESCRIPTION
## TL;DR

Add last saved to cloud timestamp to status bar.

## What changed?

- Add an extra prop in `CloudSave` type in `document.service.ts` to save last saved timestamp.
- Call upsert function when needed in `BottomBar.tsx` when user saves to cloud.
- Add status bar UI in `BottomBar.tsx`

## How to test?

To test, make changes to the original document and click "Save to Cloud", an extra state displaying last saved timestamp will show on status bar right to "Save to Cloud".

Adding an extra prop in `CloudSave` type seems to involve some changes in database schema, as it throws an error `public.upsert_document(p_content, p_format, p_id, p_last_saved) in the schema cache`.

The screenshot is taken when ignoring this error.

<img width="1512" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/2111b6d5-095c-4bd5-9026-abd4c40a4da6">

## Why make this change?

Last saved timestamp is a feature seen in other coding and productivity apps, it gives user an ease of mind. At critical times, e.g. if the user accidentally kills the session, they know where they were last time.

