### PR TITLE
Add one click format button

### DIFF
--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -104,7 +104,7 @@ export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) 
       <Group gap="xs" justify="right" w="100%" style={{ flexWrap: "nowrap" }}>
         {!premium && !isWidget && (
           <Styles.StyledToolElement onClick={handleFormat}>
-            <Text display="flex" c="teal" fz="xs" fw={600} style={{ textAlign: "center", gap: 4 }}>
+            <Text display="flex" c="blue" fz="xs" fw={600} style={{ textAlign: "center", gap: 4 }}>
               <AiOutlineEdit size="18" />
               Format
             </Text>

--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import Link from "next/link";
 import { Badge, Flex, Group, Select, Text } from "@mantine/core";
+import yaml from "js-yaml";
 import toast from "react-hot-toast";
-import { AiOutlineFullscreen, AiFillGift } from "react-icons/ai";
+import { AiOutlineFullscreen, AiFillGift, AiOutlineEdit } from "react-icons/ai";
 import { BsBoxArrowUpLeft } from "react-icons/bs";
 import { FiDownload } from "react-icons/fi";
 import { SearchInput } from "src/components/SearchInput";
@@ -30,6 +31,28 @@ function fullscreenBrowser() {
   }
 }
 
+function formatContent(content, format) {
+  try {
+    switch (format) {
+      case FileFormat.JSON:
+        return JSON.stringify(JSON.parse(content), null, 2);
+      case FileFormat.YAML:
+        return yaml.dump(yaml.load(content));
+      case FileFormat.XML:
+        return content.replace(/(>)(<)(\/*)/g, "$1\n$2$3");
+      case FileFormat.TOML:
+        return content;
+      case FileFormat.CSV:
+        return content;
+      default:
+        return content;
+    }
+  } catch (e) {
+    toast.error(`Failed to format as ${format}.`);
+    return content;
+  }
+}
+
 export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) => {
   const setVisible = useModal(state => state.setVisible);
   const setFormat = useFile(state => state.setFormat);
@@ -37,9 +60,9 @@ export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) 
   const premium = useUser(state => state.premium);
   const { contents: json, setContents: setJson } = useFile();
 
-  const formatJson = async () => {
-    const formattedJson = JSON.stringify(JSON.parse(json), null, 2);
-    setJson({ contents: formattedJson });
+  const handleFormat = async () => {
+    const formattedContent = formatContent(json, format);
+    setJson({ contents: formattedContent });
   };
 
   return (
@@ -80,10 +103,10 @@ export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) 
       )}
       <Group gap="xs" justify="right" w="100%" style={{ flexWrap: "nowrap" }}>
         {!premium && !isWidget && (
-          <Styles.StyledToolElement onClick={() => formatJson()}>
+          <Styles.StyledToolElement onClick={handleFormat}>
             <Text display="flex" c="teal" fz="xs" fw={600} style={{ textAlign: "center", gap: 4 }}>
-              <AiFillGift size="18" />
-              Format JSON
+              <AiOutlineEdit size="18" />
+              Format
             </Text>
           </Styles.StyledToolElement>
         )}

--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Link from "next/link";
 import { Badge, Flex, Group, Select, Text } from "@mantine/core";
-import prettier from "prettier";
 import toast from "react-hot-toast";
 import { AiOutlineFullscreen, AiFillGift } from "react-icons/ai";
 import { BsBoxArrowUpLeft } from "react-icons/bs";
@@ -39,7 +38,7 @@ export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) 
   const { contents: json, setContents: setJson } = useFile();
 
   const formatJson = async () => {
-    const formattedJson = await prettier.format(json, { parser: "json" });
+    const formattedJson = JSON.stringify(JSON.parse(json), null, 2);
     setJson({ contents: formattedJson });
   };
 

--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Link from "next/link";
 import { Badge, Flex, Group, Select, Text } from "@mantine/core";
+import prettier from "prettier";
 import toast from "react-hot-toast";
-import { AiOutlineFullscreen } from "react-icons/ai";
-import { AiFillGift } from "react-icons/ai";
+import { AiOutlineFullscreen, AiFillGift } from "react-icons/ai";
 import { BsBoxArrowUpLeft } from "react-icons/bs";
 import { FiDownload } from "react-icons/fi";
 import { SearchInput } from "src/components/SearchInput";
@@ -36,6 +36,12 @@ export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) 
   const setFormat = useFile(state => state.setFormat);
   const format = useFile(state => state.format);
   const premium = useUser(state => state.premium);
+  const { contents: json, setContents: setJson } = useFile();
+
+  const formatJson = async () => {
+    const formattedJson = await prettier.format(json, { parser: "json" });
+    setJson({ contents: formattedJson });
+  };
 
   return (
     <Styles.StyledTools>
@@ -74,6 +80,15 @@ export const Toolbar: React.FC<{ isWidget?: boolean }> = ({ isWidget = false }) 
         </Group>
       )}
       <Group gap="xs" justify="right" w="100%" style={{ flexWrap: "nowrap" }}>
+        {!premium && !isWidget && (
+          <Styles.StyledToolElement onClick={() => formatJson()}>
+            <Text display="flex" c="teal" fz="xs" fw={600} style={{ textAlign: "center", gap: 4 }}>
+              <AiFillGift size="18" />
+              Format JSON
+            </Text>
+          </Styles.StyledToolElement>
+        )}
+
         {!premium && !isWidget && (
           <Styles.StyledToolElement onClick={() => setVisible("premium")(true)}>
             <Text display="flex" c="teal" fz="xs" fw={600} style={{ textAlign: "center", gap: 4 }}>


### PR DESCRIPTION
## TL;DR

Add a one click format button to the main editor.

## What changed?

- Add a utility function that formats file content based on file type.
- Add a button UI in Toolbar that controls the formatting of the file content.

## How to test?

Open a file under JSON, YAML or XML format and click format to see the change. Other file formats should stay the same after formatting.

JSON before format:

<img width="1218" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/7c65fa2c-577b-4b24-a3bd-f903980e8837">

JSON after format:

<img width="1225" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/f59991f8-be84-49cd-816b-85a270ef3f65">

YAML before format:

<img width="1237" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/e86a5178-354f-4e4a-b4b3-f9da01ef8cdd">

YAML after format:

<img width="1235" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/e601b5ec-8572-44b7-affd-3b6fe6bbbcdf">

XML before format:

<img width="1231" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/f1e88122-9878-44fa-be88-a7519f1194a5">

XML after format:

<img width="1224" alt="image" src="https://github.com/AykutSarac/jsoncrack.com/assets/71319123/2f9d538c-dd49-4264-b49e-1af01c0b6c6f">

## Why make this change?

One click format or in the future configurable format on save could be a really handy feature when bulk editing files like JSON and yaml.
