### PR TITLE
Add hyperlink to LICENSE file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ We have a list of [help wanted](https://github.com/AykutSarac/jsoncrack.com/issu
 
 ## License
 
-See `LICENSE` for more information.
+See  [`LICENSE`](/LICENSE) for more information.


### PR DESCRIPTION
## Description

This PR adds a direct hyperlink to the `LICENSE` file in the `README.md` to improve accessibility and user experience.

## Problem

- The `README.md` references the `LICENSE` file but does not provide a direct link.
- Users who want to view the licensing terms must navigate manually to the `LICENSE` file in the repository.
- This can be inconvenient and may deter users from reviewing the license information.

## Solution

- Added a hyperlink to the `LICENSE` file in the `README.md`.
- This allows users to access the license information with a single click directly from the `README`.

## Impact

- Enhances documentation usability.
- No changes to code or functionality.
- Improves transparency regarding licensing terms.

## Testing

- Clicked the new `LICENSE` link in the `README.md` to ensure it correctly redirects to the `LICENSE` file.

## Notes

- This is a minor documentation update aimed at improving user experience.
- No dependencies or related issues.