### PR TITLE
Improve accessibility: added aria-label and replaced SimpleGrid 

### DIFF
--- a/src/containers/Landing/Section1.tsx
+++ b/src/containers/Landing/Section1.tsx
@@ -88,7 +88,7 @@ export const Section1 = () => {
             maw={500}
             order={2}
           >
-            Don't waste time with JSON formatters
+            Don&apos;t waste time with JSON formatters
           </Title>
           <Text my="md" c="gray.6" fz={16} maw={510}>
             The days of getting lost in lines of code are over. JSON Crack gives you the most

--- a/src/containers/Landing/Section1.tsx
+++ b/src/containers/Landing/Section1.tsx
@@ -88,27 +88,32 @@ export const Section1 = () => {
             maw={500}
             order={2}
           >
-            Don&apos;t waste time with JSON formatters
+            Don't waste time with JSON formatters
           </Title>
           <Text my="md" c="gray.6" fz={16} maw={510}>
             The days of getting lost in lines of code are over. JSON Crack gives you the most
             optimal view of your data so you can make insights faster than ever.
           </Text>
           <List
+            component="ul"
             fz={{
               base: 16,
               xs: 18,
             }}
             fw={500}
-            component={SimpleGrid}
             icon={<LuBadgeCheck size="20" />}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, 1fr)",
+              gap: "1rem",
+              listStyleType: "none",
+              padding: 0,
+            }}
           >
-            <SimpleGrid w="fit-content" cols={2}>
-              <List.Item>Clear, concise data presentation</List.Item>
-              <List.Item>Fast decision-making</List.Item>
-              <List.Item>Grasp patterns and relationships faster</List.Item>
-              <List.Item>Share insights with teams easier</List.Item>
-            </SimpleGrid>
+            <List.Item>Clear, concise data presentation</List.Item>
+            <List.Item>Fast decision-making</List.Item>
+            <List.Item>Grasp patterns and relationships faster</List.Item>
+            <List.Item>Share insights with teams easier</List.Item>
           </List>
           <Link href="/editor" prefetch={false}>
             <Button color="#202842" size="lg" radius="md" w="fit-content" mt="sm">
@@ -119,6 +124,7 @@ export const Section1 = () => {
         <StyledDottedContainer>
           <Image className="jc" src="/assets/jsoncrack.svg" alt="json crack" loading="lazy" />
           <JsonInput
+            aria-label="JSON data"
             w={273}
             rows={12}
             className="jcode"


### PR DESCRIPTION
I initially noticed some accessibility issues in features.tsx and section1.tsx and found out that revising only the section1.tsx can improve in the same way. The audit flagged two issues: 1. missing labels for form elements and 2. list structure issues due to items not being contained within <ul> and <ol> elements. 

The original code used <SimpleGrid> for layout. I modified the code to utilize <ul> and <li> tags by setting component="ul" on <List>. This change resolved the list structure issue. 

Additionally, I applied an aria-label to the JsonInput in section1.tsx. I guess since the mobile does not include the svg content, it did not impact the Lighthouse score on mobile. But it significantly improved accessibility on desktop, so I chose to leave it. 

I am submitting this pull request and would appreciate insights into managing such platform specific discrepancies in accessibility. 

Closes #423 