### PR TITLE
Use nginx-unprivileged image; fix exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ COPY . .
 RUN corepack enable pnpm && pnpm run build
 
 # Stage 3: Production image
-FROM nginx:stable AS production
+FROM nginxinc/nginx-unprivileged:stable AS production
 WORKDIR /app
 COPY --from=builder /app/out /app
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+EXPOSE 8080


### PR DESCRIPTION
Thank you for creating such a great tool!

Two minor changes:

- Changed the base Docker image for the `production` stage to `nginx-unprivileged` for better security (i.e., does not run as `root`)
    - Added the `nginxinc` namespace to remove ambiguity and ensure the official `nginx` image is used
- Fixed the exposed port in the `Dockerfile` to match the listening port in `nginx.conf`