### PR TITLE
fix typo in error pages' title

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -8,7 +8,7 @@ import Layout from "src/layout/Layout";
 const NotFound = () => {
   return (
     <Layout>
-      <NextSeo {...SEO} title="404 | ToDiagram" noindex />
+      <NextSeo {...SEO} title="404 | JSON Crack" noindex />
       <Stack mt={100} justify="center" align="center">
         <Title fz={150} style={{ fontFamily: "monospace" }}>
           404

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -10,7 +10,7 @@ const Custom500 = () => {
 
   return (
     <Layout>
-      <NextSeo {...SEO} title="Unexpected Error Occurred | ToDiagram" />
+      <NextSeo {...SEO} title="Unexpected Error Occurred | JSON Crack" />
       <Stack mt={100} justify="center" align="center">
         <Title fz={150} style={{ fontFamily: "monospace" }}>
           500


### PR DESCRIPTION
Hello,

2 pages are named after "ToDiagram" when I assume that in this repo they should be named after "JSON Crack"