### PR TITLE
Use monaco-editor node package instead of CDN for offline editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-unused-imports": "^3.2.0",
+    "monaco-editor": "^0.34.0",
     "prettier": "^3.3.3",
     "ts-node": "^10.9.2",
     "typescript": "5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 7.11.2(react@18.3.1)
       '@monaco-editor/react':
         specifier: ^4.6.0
-        version: 4.6.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.6.0(monaco-editor@0.34.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^7.118.0
         version: 7.118.0(next@14.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -180,6 +180,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^3.2.0
         version: 3.2.0(@typescript-eslint/eslint-plugin@7.17.0(@typescript-eslint/parser@7.17.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)
+      monaco-editor:
+        specifier: ^0.34.0
+        version: 0.34.0
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -1975,8 +1978,8 @@ packages:
     resolution: {integrity: sha512-2emPTb1reeLLYwHxyVx993iYyCHEiRRO+y8NFXFPL5kl5q14sgTK76cXyEKkeKCHeRw35SfdkUJ10Q1KfHuiIQ==}
     engines: {node: '>= 0.4'}
 
-  monaco-editor@0.50.0:
-    resolution: {integrity: sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==}
+  monaco-editor@0.34.0:
+    resolution: {integrity: sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ==}
 
   mousetrap@1.6.5:
     resolution: {integrity: sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==}
@@ -3076,15 +3079,15 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@monaco-editor/loader@1.4.0(monaco-editor@0.50.0)':
+  '@monaco-editor/loader@1.4.0(monaco-editor@0.34.0)':
     dependencies:
-      monaco-editor: 0.50.0
+      monaco-editor: 0.34.0
       state-local: 1.0.7
 
-  '@monaco-editor/react@4.6.0(monaco-editor@0.50.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@monaco-editor/react@4.6.0(monaco-editor@0.34.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@monaco-editor/loader': 1.4.0(monaco-editor@0.50.0)
-      monaco-editor: 0.50.0
+      '@monaco-editor/loader': 1.4.0(monaco-editor@0.34.0)
+      monaco-editor: 0.34.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -4069,7 +4072,7 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.17.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
@@ -4081,7 +4084,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4102,7 +4105,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -4847,7 +4850,7 @@ snapshots:
       hasown: 2.0.2
       isarray: 2.0.5
 
-  monaco-editor@0.50.0: {}
+  monaco-editor@0.34.0: {}
 
   mousetrap@1.6.5: {}
 

--- a/public/monaco-editor
+++ b/public/monaco-editor
@@ -1,0 +1,1 @@
+../node_modules/.pnpm/monaco-editor@0.34.0

--- a/src/containers/Editor/components/TextEditor.tsx
+++ b/src/containers/Editor/components/TextEditor.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import { LoadingOverlay } from "@mantine/core";
 import styled from "styled-components";
-import Editor, { type EditorProps, loader, useMonaco } from "@monaco-editor/react";
+import Editor, { type EditorProps, useMonaco, loader } from "@monaco-editor/react";
 import useConfig from "src/store/useConfig";
 import useFile from "src/store/useFile";
 
+
 loader.config({
   paths: {
-    vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.0/min/vs",
+    vs: "node_modules/.pnpm/monaco-editor@0.50.0/node_modules/monaco-editor/min/vs",
   },
 });
+
 
 const editorOptions: EditorProps["options"] = {
   formatOnPaste: true,

--- a/src/containers/Editor/components/TextEditor.tsx
+++ b/src/containers/Editor/components/TextEditor.tsx
@@ -5,13 +5,17 @@ import Editor, { type EditorProps, useMonaco, loader } from "@monaco-editor/reac
 import useConfig from "src/store/useConfig";
 import useFile from "src/store/useFile";
 
+let monaco_url = "./monaco-editor/node_modules/monaco-editor/min/vs"
+
+if (window.navigator.onLine) {
+  monaco_url = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.0/min/vs"
+}
 
 loader.config({
   paths: {
-    vs: './monaco-editor/node_modules/monaco-editor/min/vs',
+    vs: monaco_url,
   },
 });
-
 
 const editorOptions: EditorProps["options"] = {
   formatOnPaste: true,

--- a/src/containers/Editor/components/TextEditor.tsx
+++ b/src/containers/Editor/components/TextEditor.tsx
@@ -8,7 +8,7 @@ import useFile from "src/store/useFile";
 
 loader.config({
   paths: {
-    vs: "node_modules/.pnpm/monaco-editor@0.50.0/node_modules/monaco-editor/min/vs",
+    vs: './monaco-editor/node_modules/monaco-editor/min/vs',
   },
 });
 

--- a/src/containers/Editor/components/TextEditor.tsx
+++ b/src/containers/Editor/components/TextEditor.tsx
@@ -5,10 +5,10 @@ import Editor, { type EditorProps, useMonaco, loader } from "@monaco-editor/reac
 import useConfig from "src/store/useConfig";
 import useFile from "src/store/useFile";
 
-let monaco_url = "./monaco-editor/node_modules/monaco-editor/min/vs"
+let monaco_url = "./monaco-editor/node_modules/monaco-editor/min/vs";
 
 if (window.navigator.onLine) {
-  monaco_url = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.0/min/vs"
+  monaco_url = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.0/min/vs";
 }
 
 loader.config({


### PR DESCRIPTION
As mentioned by #368, the editor should be able to work offline. This PR adds monaco-editor as a dev dependency, and simlinks it into the public directory, so that the editor will work offline. It will continue to use the CDN if there is an internet connection.