### PR TITLE
upgrade cdnjs link for monaco-editor to 0.52.2

### DIFF
--- a/src/features/editor/TextEditor.tsx
+++ b/src/features/editor/TextEditor.tsx
@@ -7,7 +7,7 @@ import useFile from "src/store/useFile";
 
 loader.config({
   paths: {
-    vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.0/min/vs",
+    vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs",
   },
 });
 


### PR DESCRIPTION
Hello,
Should the version follow here the one defined there ?https://github.com/AykutSarac/jsoncrack.com/blob/46d1182a5d59f7a657de6cb2035bb5926c270afb/pnpm-lock.yaml#L25 
 