### PR TITLE
Add Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/aykutsarac/jsoncrack:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ docker compose up
 # Go to http://localhost:8888
 ```
 
+### Prebuilt Docker Image
+
+A prebuilt Docker image of JSON Crack is available on GitHub Container Registry. You can pull and run the image using the following commands:
+
+```console
+# Pull the prebuilt Docker image
+docker pull ghcr.io/aykutsarac/jsoncrack:latest
+
+# Run the Docker container
+docker run -p 8888:8080 ghcr.io/aykutsarac/jsoncrack:latest
+
+# Go to http://localhost:8888
+```
+
 <!-- LICENSE -->
 
 ## License


### PR DESCRIPTION
Related to #434

Add a prebuilt Docker image of JSON Crack to GitHub Container Registry.

* **README.md**
  - Add instructions for using the prebuilt Docker image.
  - Mention the GitHub Container Registry as the source.

* **.github/workflows/docker-image.yml**
  - Create a new GitHub Actions workflow file.
  - Add steps to build Docker image.
  - Add steps to push Docker image to GitHub Container Registry.

