### PR TITLE
fix: int64/long data loss of accuracy in JSON parsing

### DIFF
--- a/src/features/editor/views/GraphView/CustomNode/TextRenderer.tsx
+++ b/src/features/editor/views/GraphView/CustomNode/TextRenderer.tsx
@@ -10,7 +10,7 @@ const StyledRow = styled.span`
   vertical-align: middle;
 `;
 
-export function displayValue(val: any) {
+function displayValue(val: any) {
   if (typeof val === "string") {
     // Remove wrapping quotes if present
     const unquoted = val.replace(/^"(.*)"$/, "$1");

--- a/src/features/editor/views/TreeView/Value.tsx
+++ b/src/features/editor/views/TreeView/Value.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { DefaultTheme } from "styled-components";
 import { useTheme } from "styled-components";
-import { displayValue } from '../GraphView/CustomNode/TextRenderer';
+import { TextRenderer } from "../GraphView/CustomNode/TextRenderer";
 
 
 type TextColorFn = {
@@ -37,7 +37,7 @@ export const Value = (props: ValueProps) => {
         }),
       }}
     >
-      {displayValue(value)}
+        <TextRenderer>{JSON.stringify(value)}</TextRenderer>
     </span>
   );
 };

--- a/src/lib/utils/jsonAdapter.ts
+++ b/src/lib/utils/jsonAdapter.ts
@@ -1,16 +1,15 @@
 import type { ParseError } from "jsonc-parser";
 import { FileFormat } from "../../enums/file.enum";
 
-// ...existing code...
+// Removes unused capture groups from the regex replacement function
 function quoteLargeNumbers(input: string): string {
   // Matches numbers with 16+ digits after : or - (YAML key or array), not already in quotes
   // Also matches numbers in arrays and negative numbers
   return input.replace(
     /((:\s*|- )(-?\d{16,}))(?!\s*["\d])/g,
-    (match, p1, p2, p3) => p1.replace(p3, `"${p3}"`)
+    (_match, p1, _p2, p3) => p1.replace(p3, `"${p3}"`)
   );
 }
-// ...existing code...
 
 export const contentToJson = (value: string, format = FileFormat.JSON): Promise<object> => {
   return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
Big int I used: `12345678999192823232`


Before:(JSON)
<img width="1403" alt="image" src="https://github.com/user-attachments/assets/19609353-0cb0-42df-929a-ea13ba9ee620" />

After:(JSON)
<img width="985" alt="image" src="https://github.com/user-attachments/assets/1f8e7436-4789-4293-b393-5e88be90e00e" />


Before:(Yaml)
<img width="1377" alt="image" src="https://github.com/user-attachments/assets/2487c9f7-c6db-4730-b201-e8de4eff8d9b" />


After:(Yaml)
<img width="976" alt="image" src="https://github.com/user-attachments/assets/c76f9c86-e018-420f-86aa-a35b025f423b" />

Before:(XML)
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/69cbd7bd-cc48-4645-a437-2a556b05b211" />

After:(XML)
<img width="943" alt="image" src="https://github.com/user-attachments/assets/34e1ff96-ff64-42f5-ae9e-ac9894f373c8" />

Before:(CSV)
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/b14d9240-9ee5-43e3-8541-f98dafbbbca7" />

After:(CSV)
<img width="969" alt="image" src="https://github.com/user-attachments/assets/f83ade01-adac-4c49-a632-43af7192651f" />

