### PR TITLE
fix: Tree View Reload Crashes

### DIFF
--- a/src/store/useJson.ts
+++ b/src/store/useJson.ts
@@ -8,7 +8,7 @@ interface JsonActions {
 }
 
 const initialStates = {
-  json: "",
+  json: "{}",
   loading: true,
 };
 


### PR DESCRIPTION
This PR addresses the issue where reloading the page in Tree view causes the app to crash due to an null JSON string being parsed.
By ensuring that the zustand store always initializes with valid JSON (i.e., "{}"), we eliminate the risk of invalid JSON parsing in the Tree view component.

Before Fix:

https://github.com/user-attachments/assets/c014a8d7-9258-4fd0-bbac-de0dbf1a0e10

After Fix:


https://github.com/user-attachments/assets/1685b61d-2a8f-4ca0-addb-1032e25db0db


closes #477 
