### PR TITLE
fix: remove outdated gofmt.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "axios": "^1.9.0",
     "dayjs": "^1.11.13",
     "fast-xml-parser": "^5.2.3",
-    "gofmt.js": "^0.0.2",
     "html-to-image": "1.11.11",
     "jq-web": "^0.5.1",
     "js-cookie": "^3.0.5",

--- a/src/features/modals/TypeModal/index.tsx
+++ b/src/features/modals/TypeModal/index.tsx
@@ -73,16 +73,7 @@ export const TypeModal = ({ opened, onClose }: ModalProps) => {
   React.useEffect(() => {
     if (opened) {
       try {
-        if (selectedType === Language.Go) {
-          import("../../../lib/utils/json2go").then(jtg => {
-            import("gofmt.js").then(gofmt => {
-              const types = jtg.default(getJson());
-              setType(gofmt.default(types.go));
-            });
-          });
-        } else {
-          transformer({ value: getJson() }).then(setType);
-        }
+        transformer({ value: getJson() }).then(setType);
       } catch (error) {
         console.error(error);
       }

--- a/src/lib/utils/generateType.ts
+++ b/src/lib/utils/generateType.ts
@@ -6,16 +6,8 @@ export const generateType = async (input: string, format: FileFormat, output: Ty
     const inputToJson = await contentToJson(input, format);
     const jsonString = JSON.stringify(inputToJson);
 
-    if (output === TypeLanguage.Go) {
-      const json2go = await import("../../lib/utils/json2go.js");
-      const gofmt = await import("gofmt.js");
-      const types = json2go.default(jsonString);
-
-      return gofmt.default(types.go);
-    } else {
-      const { run } = await import("json_typegen_wasm");
-      return run("Root", jsonString, JSON.stringify({ output_mode: output }));
-    }
+    const { run } = await import("json_typegen_wasm");
+    return run("Root", jsonString, JSON.stringify({ output_mode: output }));
   } catch (error) {
     console.error(error);
     return "";


### PR DESCRIPTION
The gofmt.js package has not been updated in several years and is considered unmaintained. Relying on outdated packages can introduce security vulnerabilities and compatibility issues down the line. The functionality it provided is now handled by an existing, more modern dependency, which simplifies the codebase and reduces the overall dependency footprint.