### PR TITLE
Added edit, save, and cancel buttons to the nodes

### DIFF
--- a/src/features/modals/EditValueModal/index.tsx
+++ b/src/features/modals/EditValueModal/index.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import type { ModalProps } from "@mantine/core";
+import { Modal, Button, TextInput, Stack, Flex } from "@mantine/core";
+
+interface EditValueModalProps extends ModalProps {
+  initialValue: string;
+  onSave: (newValue: string) => void;
+}
+
+export const EditValueModal = ({ opened, onClose, initialValue, onSave }: EditValueModalProps) => {
+  const [value, setValue] = useState(initialValue);
+
+  const handleSave = () => {
+    onSave(value);
+    onClose && onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Edit Value" centered>
+      <Stack>
+        <TextInput
+          label="Value"
+          value={value}
+          onChange={e => setValue(e.currentTarget.value)}
+          autoFocus
+        />
+        <Flex justify="flex-end" gap="sm">
+          <Button variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} color="blue">
+            Save
+          </Button>
+        </Flex>
+      </Stack>
+    </Modal>
+  );
+};

--- a/src/features/modals/NodeModal/index.tsx
+++ b/src/features/modals/NodeModal/index.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ModalProps } from "@mantine/core";
-import { Modal, Stack, Text, ScrollArea, Flex, CloseButton } from "@mantine/core";
+import { Modal, Stack, Text, ScrollArea, Flex, CloseButton, Button, Textarea } from "@mantine/core";
 import { CodeHighlight } from "@mantine/code-highlight";
 import type { NodeData } from "../../../types/graph";
 import useGraph from "../../editor/views/GraphView/stores/useGraph";
+import useJson from "../../../store/useJson";
+import useFile from "../../../store/useFile";
 
 // return object from json removing array and object fields
 const normalizeNodeData = (nodeRows: NodeData["text"]) => {
@@ -26,12 +28,106 @@ const jsonPathToString = (path?: NodeData["path"]) => {
   return `$[${segments.join("][")}]`;
 };
 
+
 export const NodeModal = ({ opened, onClose }: ModalProps) => {
   const nodeData = useGraph(state => state.selectedNode);
+  const setJson = useJson(state => state.setJson);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState("");
+
+  const handleEdit = () => {
+    // Get the full object at this node's path from the JSON
+    if (nodeData?.path) {
+      try {
+        const json = useJson.getState().json;
+        const parsedJson = JSON.parse(json);
+        let current = parsedJson;
+        
+        // Navigate to the target using the path
+        for (let i = 0; i < nodeData.path.length; i++) {
+          current = current[nodeData.path[i]];
+        }
+        
+        // Set the edited content to the full object/value at this path
+        setEditedContent(JSON.stringify(current, null, 2));
+        setIsEditing(true);
+      } catch (error) {
+        alert("Error loading content for editing.");
+      }
+    }
+  };
+
+  const handleSave = () => {
+    try {
+      // Get the current JSON
+      const json = useJson.getState().json;
+      const parsedJson = JSON.parse(json);
+
+      // Update the value at the node's path
+      if (nodeData?.path) {
+        let current = parsedJson;
+        const path = nodeData.path;
+
+        // Navigate to the parent of the target
+        for (let i = 0; i < path.length - 1; i++) {
+          current = current[path[i]];
+        }
+
+        // Update the final key with the new value
+        const lastKey = path[path.length - 1];
+        
+        // Get the existing object at this path to preserve nested properties
+        const existingValue = current[lastKey];
+        
+        if (typeof existingValue === "object" && existingValue !== null) {
+          // If the existing value is an object/array, parse the edited content as JSON
+          try {
+            current[lastKey] = JSON.parse(editedContent);
+          } catch {
+            alert("Invalid JSON format for this object.");
+            return;
+          }
+        } else {
+          // If it's a primitive, try to parse as JSON first, then treat as string
+          try {
+            current[lastKey] = JSON.parse(editedContent);
+          } catch {
+            current[lastKey] = editedContent;
+          }
+        }
+
+        // Update both the file contents and JSON store
+        const updatedJson = JSON.stringify(parsedJson, null, 2);
+        useFile.getState().setContents({ contents: updatedJson });
+        setIsEditing(false);
+      }
+    } catch (error) {
+      alert("Error saving changes. Please check your input.");
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditedContent("");
+  };
 
   return (
     <Modal size="auto" opened={opened} onClose={onClose} centered withCloseButton={false}>
       <Stack pb="sm" gap="sm">
+        {isEditing ? (
+          <Flex gap="xs" style={{ alignSelf: "flex-end" }}>
+            <Button mb="xs" size="xs" onClick={handleSave} color="green" style={{ width: 80 }}>
+              Save
+            </Button>
+            <Button mb="xs" size="xs" onClick={handleCancel} color="red" style={{ width: 80 }}>
+              Cancel
+            </Button>
+          </Flex>
+        ) : (
+          <Button mb="xs" size="xs" onClick={handleEdit} style={{ alignSelf: "flex-end", width: 80 }}>
+            Edit
+          </Button>
+        )}
         <Stack gap="xs">
           <Flex justify="space-between" align="center">
             <Text fz="xs" fw={500}>
@@ -39,15 +135,26 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
             </Text>
             <CloseButton onClick={onClose} />
           </Flex>
-          <ScrollArea.Autosize mah={250} maw={600}>
-            <CodeHighlight
-              code={normalizeNodeData(nodeData?.text ?? [])}
-              miw={350}
-              maw={600}
-              language="json"
-              withCopyButton
+          {isEditing ? (
+            <Textarea
+              value={editedContent}
+              onChange={e => setEditedContent(e.currentTarget.value)}
+              placeholder="Edit JSON content..."
+              minRows={6}
+              maxRows={12}
+              style={{ fontFamily: "monospace" }}
             />
-          </ScrollArea.Autosize>
+          ) : (
+            <ScrollArea.Autosize mah={250} maw={600}>
+              <CodeHighlight
+                code={normalizeNodeData(nodeData?.text ?? [])}
+                miw={350}
+                maw={600}
+                language="json"
+                withCopyButton
+              />
+            </ScrollArea.Autosize>
+          )}
         </Stack>
         <Text fz="xs" fw={500}>
           JSON Path

--- a/src/features/modals/index.ts
+++ b/src/features/modals/index.ts
@@ -6,3 +6,5 @@ export { SchemaModal } from "./SchemaModal";
 export { JQModal } from "./JQModal";
 export { TypeModal } from "./TypeModal";
 export { JPathModal } from "./JPathModal";
+
+export { EditValueModal } from "./EditValueModal";


### PR DESCRIPTION
When a user clicks on a node when viewing the graph, a modal window should pop up with an edit button to edit the contents of the node. When clicked, the edit button should be replaced with a save and cancel button. When saved, the content should updated the nodes both on the graph and on the left hand visualizer.