### PR TITLE
Enable Editing and Saving of Graph Nodes

### DIFF
--- a/src/features/modals/NodeModal/index.tsx
+++ b/src/features/modals/NodeModal/index.tsx
@@ -2,21 +2,84 @@ import React, { useState, useEffect } from "react";
 import type { ModalProps } from "@mantine/core";
 import { Modal, Stack, Text, ScrollArea, Flex, CloseButton } from "@mantine/core";
 import { CodeHighlight } from "@mantine/code-highlight";
+import { toast } from "react-hot-toast";
+import useFile from "../../../store/useFile";
+import useJson from "../../../store/useJson";
 import type { NodeData } from "../../../types/graph";
 import useGraph from "../../editor/views/GraphView/stores/useGraph";
 
 // return object from json removing array and object fields
 const normalizeNodeData = (nodeRows: NodeData["text"]) => {
   if (!nodeRows || nodeRows.length === 0) return "{}";
-  if (nodeRows.length === 1 && !nodeRows[0].key) return `${nodeRows[0].value}`;
+  if (nodeRows.length === 1 && !nodeRows[0].key) {
+    return JSON.stringify(nodeRows[0].value, null, 2);
+  }
 
-  const obj = {};
+  const obj: Record<string, unknown> = {};
   nodeRows?.forEach(row => {
     if (row.type !== "array" && row.type !== "object") {
       if (row.key) obj[row.key] = row.value;
     }
   });
   return JSON.stringify(obj, null, 2);
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const pathsEqual = (a?: NodeData["path"], b?: NodeData["path"]) => {
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  return a.every((segment, index) => segment === b[index]);
+};
+
+const refreshSelectedNode = (path?: NodeData["path"]) => {
+  if (!path) return;
+  const graphState = useGraph.getState();
+  const updatedNode = graphState.nodes.find(node => pathsEqual(node.path, path));
+  if (updatedNode) {
+    graphState.setSelectedNode(updatedNode);
+  }
+};
+
+const applyNodePatch = (data: unknown, path: NodeData["path"], patch: unknown): unknown => {
+  if (!path) {
+    throw new Error("Unable to resolve the selected node path.");
+  }
+
+  if (path.length === 0) {
+    if (isPlainObject(data) && isPlainObject(patch)) {
+      return { ...data, ...patch };
+    }
+    return patch;
+  }
+
+  let parent: any = data;
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const segment = path[i];
+    if (parent == null || typeof parent !== "object") {
+      throw new Error("Unable to resolve the selected node path.");
+    }
+    parent = parent[segment as keyof typeof parent];
+  }
+
+  const lastSegment = path[path.length - 1];
+  if (lastSegment === undefined) {
+    return patch;
+  }
+
+  const currentValue = parent?.[lastSegment as keyof typeof parent];
+  if (isPlainObject(currentValue) && isPlainObject(patch)) {
+    parent[lastSegment as keyof typeof parent] = {
+      ...currentValue,
+      ...patch,
+    };
+  } else {
+    parent[lastSegment as keyof typeof parent] = patch;
+  }
+
+  return data;
 };
 
 // return json path in the format $["customer"]
@@ -28,6 +91,9 @@ const jsonPathToString = (path?: NodeData["path"]) => {
 
 export const NodeModal = ({ opened, onClose }: ModalProps) => {
   const nodeData = useGraph(state => state.selectedNode);
+  const getJson = useJson(state => state.getJson);
+  const setJson = useJson(state => state.setJson);
+  const setContents = useFile(state => state.setContents);
   const [editing, setEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(normalizeNodeData(nodeData?.text ?? []));
   const [originalContent, setOriginalContent] = useState(editedContent); // Store original content
@@ -42,10 +108,37 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
     setEditing(true);
   };
 
-  const handleSave = () => {
-    setOriginalContent(editedContent); // Save changes
-    setEditing(false);
-    // Add save functionality here
+  const handleSave = async () => {
+    if (!nodeData) return;
+    if (!nodeData.path) {
+      toast.error("This node cannot be edited.");
+      return;
+    }
+
+    try {
+      const parsedPatch = JSON.parse(editedContent);
+      const normalizedPatch = JSON.stringify(parsedPatch, null, 2);
+      const currentJson = getJson();
+      const parsedJson = JSON.parse(currentJson);
+      const updatedJson = applyNodePatch(parsedJson, nodeData.path, parsedPatch);
+      const serializedJson = JSON.stringify(updatedJson, null, 2);
+
+      setJson(serializedJson);
+      await setContents({
+        contents: serializedJson,
+        hasChanges: true,
+        propagateGraph: false,
+      });
+
+      setEditedContent(normalizedPatch);
+      setOriginalContent(normalizedPatch);
+      refreshSelectedNode(nodeData.path);
+      setEditing(false);
+      toast.success("Node updated");
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to save changes. Please ensure the JSON is valid.");
+    }
   };
 
   const handleCancel = () => {
@@ -67,14 +160,14 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
             {editing ? (
               <textarea
                 value={editedContent}
-                onChange={(e) => setEditedContent(e.target.value)}
+                onChange={e => setEditedContent(e.target.value)}
                 style={{
-                  width: '100%',
-                  height: '100%',
-                  borderRadius: '5px',
-                  border: '1px solid #ccc',
-                  padding: '5px',
-                  fontSize: '1rem',
+                  width: "100%",
+                  height: "100%",
+                  borderRadius: "5px",
+                  border: "1px solid #ccc",
+                  padding: "5px",
+                  fontSize: "1rem",
                 }}
               />
             ) : (
@@ -86,18 +179,18 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
                 withCopyButton
               />
             )}
-            <Flex justify="flex-end" align="flex-end" style={{ marginTop: '10px' }}>
+            <Flex justify="flex-end" align="flex-end" style={{ marginTop: "10px" }}>
               {!editing ? (
                 <button
                   onClick={handleEdit}
                   style={{
-                    padding: '5px 10px',
-                    borderRadius: '5px',
-                    backgroundColor: '#36393e',
-                    color: '#fff',
-                    fontSize: '1rem',
-                    border: 'none',
-                    cursor: 'pointer'
+                    padding: "5px 10px",
+                    borderRadius: "5px",
+                    backgroundColor: "#36393e",
+                    color: "#fff",
+                    fontSize: "1rem",
+                    border: "none",
+                    cursor: "pointer",
                   }}
                 >
                   Edit
@@ -107,14 +200,14 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
                   <button
                     onClick={handleSave}
                     style={{
-                      padding: '5px 10px',
-                      borderRadius: '5px',
-                      backgroundColor: '#36393e',
-                      color: '#fff',
-                      fontSize: '1rem',
-                      border: 'none',
-                      cursor: 'pointer',
-                      marginRight: '5px'
+                      padding: "5px 10px",
+                      borderRadius: "5px",
+                      backgroundColor: "#36393e",
+                      color: "#fff",
+                      fontSize: "1rem",
+                      border: "none",
+                      cursor: "pointer",
+                      marginRight: "5px",
                     }}
                   >
                     Save
@@ -122,13 +215,13 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
                   <button
                     onClick={handleCancel}
                     style={{
-                      padding: '5px 10px',
-                      borderRadius: '5px',
-                      backgroundColor: '#36393e',
-                      color: '#fff',
-                      fontSize: '1rem',
-                      border: 'none',
-                      cursor: 'pointer'
+                      padding: "5px 10px",
+                      borderRadius: "5px",
+                      backgroundColor: "#36393e",
+                      color: "#fff",
+                      fontSize: "1rem",
+                      border: "none",
+                      cursor: "pointer",
                     }}
                   >
                     Cancel

--- a/src/store/useFile.ts
+++ b/src/store/useFile.ts
@@ -17,6 +17,7 @@ type SetContents = {
   hasChanges?: boolean;
   skipUpdate?: boolean;
   format?: FileFormat;
+  propagateGraph?: boolean;
 };
 
 type Query = string | string[] | undefined;
@@ -99,7 +100,13 @@ const useFile = create<FileStates & JsonActions>()((set, get) => ({
       console.warn("The content was unable to be converted, so it was cleared instead.");
     }
   },
-  setContents: async ({ contents, hasChanges = true, skipUpdate = false, format }) => {
+  setContents: async ({
+    contents,
+    hasChanges = true,
+    skipUpdate = false,
+    format,
+    propagateGraph = true,
+  }) => {
     try {
       set({
         ...(contents && { contents }),
@@ -119,7 +126,9 @@ const useFile = create<FileStates & JsonActions>()((set, get) => ({
         set({ hasChanges: true });
       }
 
-      debouncedUpdateJson(json);
+      if (propagateGraph) {
+        debouncedUpdateJson(json);
+      }
     } catch (error: any) {
       if (error?.mark?.snippet) return set({ error: error.mark.snippet });
       if (error?.message) set({ error: error.message });


### PR DESCRIPTION
- Expose Edit/Save/Cancel controls on the node modal so content can switch between read and edit states.

- Wire the textarea to the underlying node data, normalizing values as JSON for editing.

- Persist saved edits back to the global JSON + graph, refresh the selection, and keep the left-hand editor in sync while allowing cancellations to restore prior content.