### PR TITLE
Gabriel Wong mini project submission: feat(node-modal): add edit/save/cancel; sync editor and graph; toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Edit-in-visualization: added an Edit button to the Node Content modal that opens an inline editor where users can edit node JSON and Save/Cancel.
+- Toast notifications for save success and JSON parse/save errors.
+- Preservation of node selection after saving an edited node (when possible).
+
+### Changed
+
+- `src/features/modals/NodeModal/index.tsx` updated to include the editing UI, save/cancel handling, and syncing with `useFile` and `useJson` stores.
+
+### Files touched
+
+- src/features/modals/NodeModal/index.tsx — main implementation
+- scripts/normalize-line-endings.js — utility used during development to normalize line endings across the repo
+
+## [Previous]
+
+- See repository releases for older entries.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,59 @@
+PR Title: Add edit-in-visualization for Node Content modal (Edit / Save / Cancel) and sync with left editor
+
+Summary
+
+This PR adds an "Edit" workflow to the Node Content modal used in the graph visualization. Users can now edit the JSON value for a selected node directly in the visualization modal. When they Save, the left-hand editor's contents are updated and the graph is re-parsed. A success toast is displayed on save and an error toast is shown for invalid JSON.
+
+Key changes
+
+- `src/features/modals/NodeModal/index.tsx`
+
+  - Added Edit button and editing UI (Textarea) with Save and Cancel.
+  - Implemented `setAtPath` helper to replace the JSON value at the node's path.
+  - On Save: validate JSON, update editor contents via `useFile.setContents`, update `useJson.setJson`, attempt to preserve the edited node selection, and show toast notifications.
+
+- `scripts/normalize-line-endings.js`
+
+  - Development helper used to normalize CRLF -> LF in `src`, `pages`, and `public` directories.
+
+- `CHANGELOG.md` and `PR_DESCRIPTION.md` (this file)
+  - Documentation for reviewers and release notes.
+
+Why this change
+
+- Improves UX by letting power users edit nodes inline without switching to the left-hand editor.
+- Keeps the left-hand canonical editor in sync so edits remain source-of-truth.
+
+How to test manually (smoke test)
+
+1. Install and run the app locally:
+
+```powershell
+pnpm install
+pnpm dev
+```
+
+2. Open the app in a browser (likely at http://localhost:3000 or http://localhost:3001 if 3000 is in use).
+3. Open the Editor view and load some JSON into the left editor (or use the example data provided).
+4. In the visualization, click a node to open the Node Content modal (or open it via the UI).
+5. Click "Edit", change the JSON value in the textarea (for primitives use a quoted string when appropriate), then click "Save".
+6. Verify:
+   - A toast appears saying "Saved".
+   - The left-hand editor's content updates to reflect the edit.
+   - The visualization updates (graph node content updated). If selection can be resolved after re-parse, the same node remains selected.
+7. Try invalid JSON in the editor and click Save — verify an error toast and inline error message appear.
+
+Notes for reviewers
+
+- The selection-preservation logic uses JSONPath equality (stringified) to try and match nodes after the graph is rebuilt. This works for straightforward edits. If the structure changes drastically, the node may not be found; that is non-fatal and the code falls back gracefully.
+- The change relies on `useFile.setContents` and `useJson.setJson` to keep the left editor and graph in sync. Unit tests for `setAtPath` would be useful if we expand coverage.
+
+Files to check
+
+- `src/features/modals/NodeModal/index.tsx` — main changes
+- `src/store/useFile.ts` and `src/store/useJson.ts` — store usage (read-only in this PR)
+
+Follow-up work / optional
+
+- Add a unit test for `setAtPath` to validate nested arrays/objects and root replacement behavior.
+- Add UX tweak to optionally keep modal open after save (if users prefer in-place iterative edits).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,8 +1060,8 @@ packages:
   camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
-  caniuse-lite@1.0.30001718:
-    resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
+  caniuse-lite@1.0.30001754:
+    resolution: {integrity: sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==}
 
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -4009,7 +4009,7 @@ snapshots:
 
   camelize@1.0.1: {}
 
-  caniuse-lite@1.0.30001718: {}
+  caniuse-lite@1.0.30001754: {}
 
   chalk@3.0.0:
     dependencies:
@@ -4319,7 +4319,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.5(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.56.0)
@@ -4353,7 +4353,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4368,7 +4368,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5232,7 +5232,7 @@ snapshots:
       '@next/env': 14.2.28
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001718
+      caniuse-lite: 1.0.30001754
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1

--- a/scripts/normalize-line-endings.js
+++ b/scripts/normalize-line-endings.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const exts = ['.ts','.tsx','.js','.jsx','.json','.md','.css','.scss','.html'];
+const targets = ['src','pages','public'];
+
+function walk(dir){
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for(const e of entries){
+    const p = path.join(dir, e.name);
+    if(e.isDirectory()){
+      // skip node_modules just in case
+      if(e.name === 'node_modules') continue;
+      walk(p);
+    } else {
+      if(exts.includes(path.extname(p))){
+        try{
+          const s = fs.readFileSync(p, 'utf8');
+          const ns = s.replace(/\r\n/g, '\n');
+          if(ns !== s){
+            fs.writeFileSync(p, ns, 'utf8');
+            console.log('Converted:', p);
+          }
+        } catch(err){
+          console.error('Error reading/writing', p, err.message);
+        }
+      }
+    }
+  }
+}
+
+for(const t of targets){
+  if(fs.existsSync(t)){
+    console.log('Processing', t);
+    walk(t);
+  }
+}
+console.log('Done');

--- a/src/features/modals/NodeModal/index.tsx
+++ b/src/features/modals/NodeModal/index.tsx
@@ -1,16 +1,38 @@
-import React from "react";
+﻿import React from "react";
 import type { ModalProps } from "@mantine/core";
-import { Modal, Stack, Text, ScrollArea, Flex, CloseButton } from "@mantine/core";
+import {
+  Modal,
+  Stack,
+  Text,
+  ScrollArea,
+  Flex,
+  CloseButton,
+  Button,
+  Textarea,
+  Group,
+} from "@mantine/core";
 import { CodeHighlight } from "@mantine/code-highlight";
+import toast from "react-hot-toast";
+import { FiEdit, FiSave, FiX } from "react-icons/fi";
+import useFile from "../../../store/useFile";
+import useJson from "../../../store/useJson";
 import type { NodeData } from "../../../types/graph";
 import useGraph from "../../editor/views/GraphView/stores/useGraph";
 
 // return object from json removing array and object fields
 const normalizeNodeData = (nodeRows: NodeData["text"]) => {
+  // return valid JSON string for editing/viewing
   if (!nodeRows || nodeRows.length === 0) return "{}";
-  if (nodeRows.length === 1 && !nodeRows[0].key) return `${nodeRows[0].value}`;
 
-  const obj = {};
+  // single primitive value (like string/number/null)
+  if (nodeRows.length === 1 && !nodeRows[0].key) {
+    const v = nodeRows[0].value;
+    // ensure strings are quoted
+    if (typeof v === "string") return JSON.stringify(v);
+    return JSON.stringify(v, null, 2);
+  }
+
+  const obj: Record<string, unknown> = {};
   nodeRows?.forEach(row => {
     if (row.type !== "array" && row.type !== "object") {
       if (row.key) obj[row.key] = row.value;
@@ -28,6 +50,87 @@ const jsonPathToString = (path?: NodeData["path"]) => {
 
 export const NodeModal = ({ opened, onClose }: ModalProps) => {
   const nodeData = useGraph(state => state.selectedNode);
+  const getContents = useFile(state => state.getContents);
+  const setContents = useFile(state => state.setContents);
+  const setJson = useJson(state => state.setJson);
+
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!editing) setError(null);
+  }, [editing]);
+
+  const startEditing = () => {
+    const str = normalizeNodeData(nodeData?.text ?? []);
+    setDraft(str);
+    setEditing(true);
+  };
+
+  const setAtPath = (obj: any, path: NodeData["path"] | undefined, value: any) => {
+    if (!path || path.length === 0) return value; // replace root
+
+    // clone path traversal
+    const cloned = Array.isArray(obj) ? [...obj] : { ...obj };
+    let target: any = cloned;
+    for (let i = 0; i < path.length - 1; i++) {
+      const seg = path[i] as string | number;
+      if (typeof seg === "number") {
+        target[seg] = Array.isArray(target[seg]) ? [...target[seg]] : target[seg];
+      } else {
+        target[seg] = target[seg] && typeof target[seg] === "object" ? { ...target[seg] } : {};
+      }
+      target = target[seg];
+    }
+    const last = path[path.length - 1] as string | number;
+    target[last as any] = value;
+    return cloned;
+  };
+
+  const handleSave = async () => {
+    try {
+      // ensure draft is valid JSON
+      const newVal = JSON.parse(draft);
+
+      const contents = getContents();
+      const json = JSON.parse(contents);
+
+      const updated = setAtPath(json, nodeData?.path, newVal);
+
+      const out = JSON.stringify(updated, null, 2);
+
+      // update editor contents and graph immediately
+      await setContents({ contents: out, hasChanges: true });
+      setJson(out);
+
+      // Attempt to preserve selection: find the corresponding node in the rebuilt graph
+      try {
+        const targetPath = JSON.stringify(nodeData?.path ?? []);
+        const nodes = useGraph.getState().nodes;
+        const found = nodes.find(n => JSON.stringify(n.path ?? []) === targetPath);
+        if (found) {
+          useGraph.getState().setSelectedNode(found);
+        }
+      } catch (e) {
+        // non-fatal, ignore
+      }
+
+      toast.success("Saved");
+
+      setEditing(false);
+      onClose?.();
+    } catch (err: any) {
+      setError(err?.message ?? "Invalid JSON");
+      toast.error(err?.message ?? "Invalid JSON");
+    }
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setDraft("");
+    setError(null);
+  };
 
   return (
     <Modal size="auto" opened={opened} onClose={onClose} centered withCloseButton={false}>
@@ -37,16 +140,46 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
             <Text fz="xs" fw={500}>
               Content
             </Text>
-            <CloseButton onClick={onClose} />
+            <Group>
+              {!editing && (
+                <Button size="xs" variant="subtle" onClick={startEditing}>
+                  <FiEdit style={{ marginRight: 8 }} />
+                  Edit
+                </Button>
+              )}
+              {editing && (
+                <>
+                  <Button size="xs" color="green" onClick={handleSave}>
+                    <FiSave style={{ marginRight: 8 }} />
+                    Save
+                  </Button>
+                  <Button size="xs" color="gray" onClick={handleCancel}>
+                    <FiX style={{ marginRight: 8 }} />
+                    Cancel
+                  </Button>
+                </>
+              )}
+              <CloseButton onClick={onClose} />
+            </Group>
           </Flex>
+
           <ScrollArea.Autosize mah={250} maw={600}>
-            <CodeHighlight
-              code={normalizeNodeData(nodeData?.text ?? [])}
-              miw={350}
-              maw={600}
-              language="json"
-              withCopyButton
-            />
+            {!editing ? (
+              <CodeHighlight
+                code={normalizeNodeData(nodeData?.text ?? [])}
+                miw={350}
+                maw={600}
+                language="json"
+                withCopyButton
+              />
+            ) : (
+              <Textarea
+                value={draft}
+                onChange={e => setDraft(e.currentTarget.value)}
+                autosize
+                minRows={4}
+              />
+            )}
           </ScrollArea.Autosize>
         </Stack>
         <Text fz="xs" fw={500}>
@@ -63,6 +196,11 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
             withCopyButton
           />
         </ScrollArea.Autosize>
+        {error && (
+          <Text fz="xs" color="red">
+            {error}
+          </Text>
+        )}
       </Stack>
     </Modal>
   );


### PR DESCRIPTION
- Add edit UI in NodeModal with Save/Cancel
- Update left editor and graph via useFile.setContents and useJson.setJson
- Preserve node selection after save when possible
- Add CHANGELOG and PR_DESCRIPTION for review