### PR TITLE
Correct title of Theme Toggle toolbar button

### DIFF
--- a/apps/www/src/features/editor/Toolbar/ThemeToggle.tsx
+++ b/apps/www/src/features/editor/Toolbar/ThemeToggle.tsx
@@ -7,9 +7,10 @@ export const ThemeToggle = () => {
   const toggleDarkMode = useConfig(state => state.toggleDarkMode);
 
   return (
-    <StyledToolElement 
-      title={!darkmodeEnabled ? "Dark Mode" : "Light Mode"} 
-      onClick={() => toggleDarkMode(!darkmodeEnabled)}>
+    <StyledToolElement
+      title={!darkmodeEnabled ? "Dark Mode" : "Light Mode"}
+      onClick={() => toggleDarkMode(!darkmodeEnabled)}
+    >
       {!darkmodeEnabled ? <FaMoon size="18" /> : <FaSun size="18" />}
     </StyledToolElement>
   );


### PR DESCRIPTION
## Issue
Closes #577

## What Changed
I was using the demo app and didn't immediately recognize the Sun icon, so I found the incorrect title confusing.  I changed the title attribute to say "Light Mode" or "Dark Mode" using logic consistent with how the icon is selected.

## How to Test
Run the browser application and hover over the Sun/Moon toolbar button.

## Evidence
Screenshot is included in the issue 
