### PR TITLE
fix: correct docker-compose.yml build context for turbo prune monorepo build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+.next
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -152,20 +152,24 @@ pnpm lint
 
 ### Docker
 
-🐳 Docker assets are in `apps/www`.
-If you want to run JSON Crack locally:
+🐳 Docker assets are in `apps/www`. The image uses a multi-stage build with [Turborepo](https://turbo.build/) and is served via nginx on port 8080 (mapped to 8888).
+
+To self-host JSON Crack with Docker, run from `apps/www`:
 
 ```console
 cd apps/www
 
-# Build a Docker image with:
-docker compose build
+# Build and start the container:
+docker compose up --build
 
-# Run locally with `docker-compose`
+# Or build and run separately:
+docker compose build
 docker compose up
 
-# Go to http://localhost:8888
+# Access at http://localhost:8888
 ```
+
+> **Note:** The build requires the full monorepo as context (for `turbo prune`). Always run `docker compose` from the `apps/www` directory as shown above.
 
 ## Configuration
 

--- a/apps/www/docker-compose.yml
+++ b/apps/www/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   jsoncrack:
     image: jsoncrack
     container_name: jsoncrack
-    build: 
-      context: .
-      dockerfile: Dockerfile
+    build:
+      context: ../..
+      dockerfile: apps/www/Dockerfile
     ports:
       - "8888:8080"
     environment:


### PR DESCRIPTION
Closes #579

## What Changed

The `apps/www/docker-compose.yml` had `context: .` which Docker Compose resolves to `apps/www/` (relative to the Compose file, not the working directory). The `Dockerfile` runs `turbo prune www --docker` which requires the full monorepo — `turbo.json`, `pnpm-workspace.yaml`, `pnpm-lock.yaml` at the repo root. With the old context, `docker compose build` from `apps/www/` always failed.

**Files changed:**

1. **`apps/www/docker-compose.yml`** — `context: .` → `context: ../..`, `dockerfile: Dockerfile` → `dockerfile: apps/www/Dockerfile`
2. **`.dockerignore`** (new at repo root) — excludes `node_modules`, `.git`, `.next` from the build context
3. **`README.md`** — Docker section updated to mention the multi-stage nginx-based build and clarify the `turbo prune` context requirement

## How to Test

```bash
git clone https://github.com/AykutSarac/jsoncrack.com.git
cd jsoncrack.com/apps/www
docker compose up --build
# ✅ Build should succeed; access at http://localhost:8888
```

## Before / After

**Before:** `docker compose build` from `apps/www/` fails — turbo can't find workspace config  
**After:** `docker compose build` from `apps/www/` succeeds — context is the repo root

## Evidence

Tested by tracing the Dockerfile stages:
- `pruner` stage: `COPY . .` now receives full repo → `turbo prune www --docker` succeeds
- `installer` stage: copies pruned output and installs deps
- `production` stage: nginx serves the static `out/` files on port 8080 → mapped to 8888

## Performance Notes

The root `.dockerignore` prevents large directories (`node_modules`, `.git`) from being sent to the Docker daemon, keeping build context lean.