### PR TITLE
fix: upgrade lodash-es to 4.18.0 (CVE-2026-4800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "unrs-resolver"
     ],
     "overrides": {
-      "html-to-image": "1.11.11"
+      "html-to-image": "1.11.11",
+      "lodash-es": "4.18.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
Upgrade lodash-es from 4.17.23 to 4.18.0 to fix CVE-2026-4800.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-4800 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-4800` |
| **File** | `pnpm-lock.yaml` |

**Description**: lodash: lodash: Arbitrary code execution via untrusted input in template imports

## Changes
- `package.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
