### PR TITLE
feat: support shift wheel horizontal pan

### DIFF
--- a/packages/jsoncrack-react/src/JSONCrackComponent.tsx
+++ b/packages/jsoncrack-react/src/JSONCrackComponent.tsx
@@ -233,7 +233,7 @@ export const JSONCrack = forwardRef<JSONCrackRef, JSONCrackProps>(
         if (delta === null) return;
 
         event.preventDefault();
-        event.stopPropagation();
+        event.stopImmediatePropagation();
         viewPort.camera?.moveByInClientSpace(delta, 0, 0);
       };
 

--- a/packages/jsoncrack-react/src/JSONCrackComponent.tsx
+++ b/packages/jsoncrack-react/src/JSONCrackComponent.tsx
@@ -226,7 +226,10 @@ export const JSONCrack = forwardRef<JSONCrackRef, JSONCrackProps>(
       if (!space) return;
 
       const handleShiftWheel = (event: WheelEvent) => {
-        const delta = getShiftWheelHorizontalPanDelta(event, window.innerHeight);
+        const delta = getShiftWheelHorizontalPanDelta(
+          event,
+          space.clientWidth || window.innerWidth
+        );
         if (delta === null) return;
 
         event.preventDefault();

--- a/packages/jsoncrack-react/src/JSONCrackComponent.tsx
+++ b/packages/jsoncrack-react/src/JSONCrackComponent.tsx
@@ -25,6 +25,7 @@ import {
   buildEdgeTargetMap,
   fitGraphToViewPort,
   focusRootNode,
+  getShiftWheelHorizontalPanDelta,
   parseJsonGraph,
   setCanvasDragging,
   setViewPortZoom,
@@ -217,6 +218,24 @@ export const JSONCrack = forwardRef<JSONCrackRef, JSONCrackProps>(
 
       observer.observe(container);
       return () => observer.disconnect();
+    }, [viewPort]);
+
+    useEffect(() => {
+      if (!viewPort) return;
+      const space = containerRef.current?.querySelector<HTMLElement>(".jsoncrack-space");
+      if (!space) return;
+
+      const handleShiftWheel = (event: WheelEvent) => {
+        const delta = getShiftWheelHorizontalPanDelta(event, window.innerHeight);
+        if (delta === null) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        viewPort.camera?.moveByInClientSpace(delta, 0, 0);
+      };
+
+      space.addEventListener("wheel", handleShiftWheel, { capture: true, passive: false });
+      return () => space.removeEventListener("wheel", handleShiftWheel, { capture: true });
     }, [viewPort]);
 
     const viewPortApi = useMemo(

--- a/packages/jsoncrack-react/src/JSONCrackComponent.tsx
+++ b/packages/jsoncrack-react/src/JSONCrackComponent.tsx
@@ -232,9 +232,12 @@ export const JSONCrack = forwardRef<JSONCrackRef, JSONCrackProps>(
         );
         if (delta === null) return;
 
+        const camera = viewPort.camera;
+        if (!camera) return;
+
         event.preventDefault();
         event.stopImmediatePropagation();
-        viewPort.camera?.moveByInClientSpace(delta, 0, 0);
+        camera.moveByInClientSpace(delta, 0, 0);
       };
 
       space.addEventListener("wheel", handleShiftWheel, { capture: true, passive: false });

--- a/packages/jsoncrack-react/src/__tests__/canvasHelpers.test.ts
+++ b/packages/jsoncrack-react/src/__tests__/canvasHelpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildCanvasClassName,
   buildCanvasStyle,
   buildEdgeTargetMap,
+  getShiftWheelHorizontalPanDelta,
   parseJsonGraph,
   toJsonText,
 } from "../canvasHelpers";
@@ -141,5 +142,40 @@ describe("buildEdgeTargetMap", () => {
 
   it("returns an empty map for empty input", () => {
     expect(buildEdgeTargetMap([]).size).toBe(0);
+  });
+});
+
+describe("getShiftWheelHorizontalPanDelta", () => {
+  it("ignores wheel events without the shift key", () => {
+    expect(
+      getShiftWheelHorizontalPanDelta({ shiftKey: false, deltaX: 0, deltaY: 80, deltaMode: 0 }, 900)
+    ).toBeNull();
+  });
+
+  it("ignores shift wheel events without movement", () => {
+    expect(
+      getShiftWheelHorizontalPanDelta({ shiftKey: true, deltaX: 0, deltaY: 0, deltaMode: 0 }, 900)
+    ).toBeNull();
+  });
+
+  it("maps vertical shift wheel movement to horizontal pan", () => {
+    expect(
+      getShiftWheelHorizontalPanDelta({ shiftKey: true, deltaX: 0, deltaY: 80, deltaMode: 0 }, 900)
+    ).toBe(40);
+  });
+
+  it("falls back to horizontal wheel movement when no vertical delta is present", () => {
+    expect(
+      getShiftWheelHorizontalPanDelta({ shiftKey: true, deltaX: -60, deltaY: 0, deltaMode: 0 }, 900)
+    ).toBe(-30);
+  });
+
+  it("scales line and page deltas before panning", () => {
+    expect(
+      getShiftWheelHorizontalPanDelta({ shiftKey: true, deltaX: 0, deltaY: 2, deltaMode: 1 }, 900)
+    ).toBeCloseTo(7.15625);
+    expect(
+      getShiftWheelHorizontalPanDelta({ shiftKey: true, deltaX: 0, deltaY: 1, deltaMode: 2 }, 900)
+    ).toBe(450);
   });
 });

--- a/packages/jsoncrack-react/src/canvasHelpers.ts
+++ b/packages/jsoncrack-react/src/canvasHelpers.ts
@@ -106,6 +106,27 @@ export const setCanvasDragging = (container: HTMLElement | null, dragging: boole
   canvas.classList.toggle("dragging", dragging);
 };
 
+const DOM_DELTA_LINE = 1;
+const DOM_DELTA_PAGE = 2;
+const LINE_WHEEL_DELTA_SCALE = 7.15625;
+
+/** Convert Shift+wheel movement into a horizontal client-space pan delta. */
+export const getShiftWheelHorizontalPanDelta = (
+  event: Pick<WheelEvent, "shiftKey" | "deltaX" | "deltaY" | "deltaMode">,
+  pageDeltaScale: number
+): number | null => {
+  if (!event.shiftKey) return null;
+
+  const rawDelta = event.deltaY !== 0 ? event.deltaY : event.deltaX;
+  if (rawDelta === 0) return null;
+
+  let scale = 1;
+  if (event.deltaMode === DOM_DELTA_LINE) scale = LINE_WHEEL_DELTA_SCALE;
+  if (event.deltaMode === DOM_DELTA_PAGE) scale = pageDeltaScale;
+
+  return (rawDelta * scale) / 2;
+};
+
 /** Breathing room around the measured graph rect, expressed as a fraction of the rect's own dimensions. Using a fraction (instead of a fixed pixel value) is scale-invariant: whether we measure the graph at zoom 1 or at zoom 0.27, the padded rect expands by the same *proportion*, so translating through `translateClientRectToVirtualSpace` produces the same virtual rect regardless of current zoom. A fixed client-pixel padding would blow up in virtual space as zoom decreases and make manual Fit clicks land at a different zoom than the initial auto-fit. */
 const GRAPH_FIT_PADDING_RATIO = 0.02;
 

--- a/packages/jsoncrack-react/src/canvasHelpers.ts
+++ b/packages/jsoncrack-react/src/canvasHelpers.ts
@@ -108,7 +108,11 @@ export const setCanvasDragging = (container: HTMLElement | null, dragging: boole
 
 const DOM_DELTA_LINE = 1;
 const DOM_DELTA_PAGE = 2;
+
+// Match react-zoomable-ui's wheel panning feel: line-mode deltas use its
+// empirical pixel estimate, and panning moves at half the raw wheel delta.
 const LINE_WHEEL_DELTA_SCALE = 7.15625;
+const HORIZONTAL_WHEEL_PAN_SENSITIVITY = 0.5;
 
 /** Convert Shift+wheel movement into a horizontal client-space pan delta. */
 export const getShiftWheelHorizontalPanDelta = (
@@ -124,7 +128,7 @@ export const getShiftWheelHorizontalPanDelta = (
   if (event.deltaMode === DOM_DELTA_LINE) scale = LINE_WHEEL_DELTA_SCALE;
   if (event.deltaMode === DOM_DELTA_PAGE) scale = pageDeltaScale;
 
-  return (rawDelta * scale) / 2;
+  return rawDelta * scale * HORIZONTAL_WHEEL_PAN_SENSITIVITY;
 };
 
 /** Breathing room around the measured graph rect, expressed as a fraction of the rect's own dimensions. Using a fraction (instead of a fixed pixel value) is scale-invariant: whether we measure the graph at zoom 1 or at zoom 0.27, the padded rect expands by the same *proportion*, so translating through `translateClientRectToVirtualSpace` produces the same virtual rect regardless of current zoom. A fixed client-pixel padding would blow up in virtual space as zoom decreases and make manual Fit clicks land at a different zoom than the initial auto-fit. */


### PR DESCRIPTION
## Issue
Closes #511

## What Changed
Added support for Shift + mouse wheel horizontal panning on the JSON Crack graph canvas.

- Normal mouse wheel behavior still controls zoom.
- Shift + wheel up/down now pans the graph horizontally.
- Added tests for the Shift + wheel delta handling.

## How to Test
1. Run the app with `pnpm dev`.
2. Open the editor and load a JSON file large enough to create a wide graph.
3. Scroll normally with the mouse wheel and confirm the graph still zooms.
4. Hold `Shift` and scroll the mouse wheel up/down.
5. Confirm the graph pans horizontally in both directions.

## Evidence
**Screenshots or Video Required** — Choose one or both:

### Screenshots
- [ ] Before/after screenshots attached (for UI changes)

### Video
- [x] Screen recording of the feature in action

https://github.com/user-attachments/assets/84dd9fc6-aa7e-47e2-a7d1-294fc7189957

### Testing
- [x] Tested locally with `pnpm dev`
- [x] No console errors
- [x] Tested with large JSON files (if applicable)

## Performance Impact
No meaningful performance impact. The new wheel listener only handles `Shift + wheel` events and exits early for normal wheel events.

- [x] No performance impact
- [ ] Improved performance (explain how)
- [ ] Potential impact (explain and justify)

## Additional Notes
Automated checks passed:

- `pnpm --filter jsoncrack-react test`
- `pnpm --filter jsoncrack-react lint`
- `pnpm --filter jsoncrack-react build`